### PR TITLE
feat: enable Protect API for remote cloud connections

### DIFF
--- a/.github/instructions/api.instructions.md
+++ b/.github/instructions/api.instructions.md
@@ -29,8 +29,8 @@ This integration vendors the upstream `unifi-official-api` project under `custom
 In `__init__.py`:
 
 - Network client: Created for both local and remote modes
-- Protect client: Only for local mode
-- Validates connectivity by fetching sites
+- Protect client: Created for both local and remote modes
+- Validates connectivity by fetching sites (Network) and cameras (Protect)
 
 ## Session management
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2026.3.1] - 2026-03-22
+
+### Fixed
+
+- Fixed Unifi Remote Cloud authentication issue.
+
 ## [2026.3.0] - 2026-03-15
 
 ### Added

--- a/custom_components/unifi_insights/__init__.py
+++ b/custom_components/unifi_insights/__init__.py
@@ -178,10 +178,10 @@ async def async_setup_entry(
             _LOGGER.warning(msg)
             raise ConfigEntryAuthFailed(msg) from err
 
-        # Initialize UniFi Protect API client (only for local connections currently)
+        # Initialize UniFi Protect API client
         protect_client: UniFiProtectClient | None = None
         if is_local:
-            _LOGGER.debug("Initializing UniFi Protect API client")
+            _LOGGER.debug("Initializing UniFi Protect API client (LOCAL)")
             protect_client = UniFiProtectClient(
                 auth=auth,
                 base_url=entry.data.get(CONF_HOST, DEFAULT_API_HOST),
@@ -189,8 +189,18 @@ async def async_setup_entry(
                 timeout=30,
                 session=websession,
             )
+        else:
+            _LOGGER.debug("Initializing UniFi Protect API client (REMOTE)")
+            protect_client = UniFiProtectClient(
+                auth=auth,
+                connection_type=ConnectionType.REMOTE,
+                console_id=entry.data.get(CONF_CONSOLE_ID),
+                timeout=30,
+                session=websession,
+            )
 
-            # Verify UniFi Protect API connection by fetching cameras
+        # Verify UniFi Protect API connection by fetching cameras
+        if protect_client:
             _LOGGER.debug("Validating Protect API connection")
             try:
                 cameras = await protect_client.cameras.get_all()
@@ -205,8 +215,6 @@ async def async_setup_entry(
                     err,
                 )
                 protect_client = None
-        else:
-            _LOGGER.info("Protect API not available for remote connections")
 
     # Note: UniFiAuthenticationError is already handled in the inner try block
     # at lines 176-179, which converts it to ConfigEntryAuthFailed

--- a/custom_components/unifi_insights/api/const.py
+++ b/custom_components/unifi_insights/api/const.py
@@ -18,7 +18,7 @@ class ConnectionType(str, Enum):
 
     REMOTE: Cloud connection via Ubiquiti's API (https://api.ui.com)
             - Uses cloud API key from account.ui.com
-            - Endpoints: /v1/connector/consoles/{consoleId}/proxy/network/integration/v1/...
+            - Endpoints: /v1/connector/consoles/{consoleId}/network/integration/v1/...
     """
 
     LOCAL = "local"

--- a/custom_components/unifi_insights/api/network/client.py
+++ b/custom_components/unifi_insights/api/network/client.py
@@ -172,10 +172,10 @@ class UniFiNetworkClient(BaseUniFiClient):
 
         console_id = self._require_console_id()
 
-        # Remote: /v1/connector/consoles/{consoleId}/proxy/network/integration/v1{endpoint}
-        return (
-            f"/v1/connector/consoles/{console_id}{NETWORK_INTEGRATION_PATH}{endpoint}"
-        )
+        # Remote: /v1/connector/consoles/{consoleId}/network/integration/v1{endpoint}
+        # The connector adds /proxy/ when forwarding to the console, so strip it.
+        connector_path = NETWORK_INTEGRATION_PATH.removeprefix("/proxy")
+        return f"/v1/connector/consoles/{console_id}{connector_path}{endpoint}"
 
     def build_legacy_api_path(self, site_name: str, endpoint: str) -> str:
         """
@@ -201,9 +201,11 @@ class UniFiNetworkClient(BaseUniFiClient):
 
         console_id = self._require_console_id()
 
+        # The connector adds /proxy/ when forwarding to the console, so strip it.
+        connector_path = NETWORK_LEGACY_PATH.removeprefix("/proxy")
         return (
             f"/v1/connector/consoles/{console_id}"
-            f"{NETWORK_LEGACY_PATH}/s/{site_name}{endpoint}"
+            f"{connector_path}/s/{site_name}{endpoint}"
         )
 
     def build_legacy_global_api_path(self, endpoint: str) -> str:
@@ -224,7 +226,9 @@ class UniFiNetworkClient(BaseUniFiClient):
             return f"{NETWORK_LEGACY_PATH}{endpoint}"
 
         console_id = self._require_console_id()
-        return f"/v1/connector/consoles/{console_id}{NETWORK_LEGACY_PATH}{endpoint}"
+        # The connector adds /proxy/ when forwarding to the console, so strip it.
+        connector_path = NETWORK_LEGACY_PATH.removeprefix("/proxy")
+        return f"/v1/connector/consoles/{console_id}{connector_path}{endpoint}"
 
     @property
     def devices(self) -> DevicesEndpoint:

--- a/custom_components/unifi_insights/api/protect/client.py
+++ b/custom_components/unifi_insights/api/protect/client.py
@@ -174,12 +174,12 @@ class UniFiProtectClient(BaseUniFiClient):
             # Local: /proxy/protect/integration/v1{endpoint}
             # Note: LOCAL Protect API does NOT use /sites/{site_id} prefix
             return f"{PROTECT_INTEGRATION_PATH}{endpoint}"
-        # Remote: /v1/connector/consoles/{consoleId}/proxy/protect/...
-        # .../integration/v1/sites/{siteId}{endpoint}
-        if not site_id:
-            raise ValueError("site_id is required for REMOTE connection type")
+        # Remote: /v1/connector/consoles/{consoleId}/protect/integration/v1{endpoint}
+        # The connector adds /proxy/ when forwarding to the console, so strip it.
+        # Protect API does not use site-scoped paths (unlike Network API).
+        connector_path = PROTECT_INTEGRATION_PATH.removeprefix("/proxy")
         base = f"/v1/connector/consoles/{self._console_id}"
-        return f"{base}{PROTECT_INTEGRATION_PATH}/sites/{site_id}{endpoint}"
+        return f"{base}{connector_path}{endpoint}"
 
     @property
     def cameras(self) -> CamerasEndpoint:

--- a/custom_components/unifi_insights/manifest.json
+++ b/custom_components/unifi_insights/manifest.json
@@ -12,6 +12,6 @@
   "issue_tracker": "https://github.com/ruaan-deysel/ha-unifi-insights/issues",
   "loggers": ["custom_components.unifi_insights"],
   "usb": [],
-  "version": "2026.3.0",
+  "version": "2026.3.1",
   "zeroconf": []
 }

--- a/custom_components/unifi_insights/translations/en.json
+++ b/custom_components/unifi_insights/translations/en.json
@@ -29,12 +29,20 @@
         "title": "Remote Connection (UniFi Cloud)",
         "description": "Connect to your UniFi device via the UniFi Cloud.",
         "data": {
-          "console_id": "Console ID",
           "api_key": "API Key"
         },
         "data_description": {
-          "console_id": "Your UniFi Console ID from unifi.ui.com",
-          "api_key": "Cloud API key from your UniFi account"
+          "api_key": "Cloud API key from your UniFi account. After validation, you will choose one of the consoles that this API key can access."
+        }
+      },
+      "select_console": {
+        "title": "Select remote console",
+        "description": "Choose the UniFi console that you want to connect to.",
+        "data": {
+          "console_id": "Console"
+        },
+        "data_description": {
+          "console_id": "These consoles were discovered with your API key."
         }
       },
       "reauth_confirm": {
@@ -56,13 +64,15 @@
       }
     },
     "error": {
-      "cannot_connect": "Failed to connect to UniFi controller. Please check the host address and network connectivity.",
-      "invalid_auth": "Invalid API key. Please verify your credentials.",
-      "unknown": "An unexpected error occurred. Please check the logs for details."
+      "cannot_connect": "Failed to connect",
+      "invalid_auth": "Invalid authentication",
+      "invalid_console_id": "The selected console could not be accessed with this API key.",
+      "no_remote_consoles": "No remote UniFi consoles were found for this API key.",
+      "unknown": "Unexpected error"
     },
     "abort": {
-      "already_configured": "This device is already configured.",
-      "reauth_successful": "Re-authentication was successful.",
+      "already_configured": "Device is already configured",
+      "reauth_successful": "Re-authentication was successful",
       "account_mismatch": "The API key provided does not match the original account. Please use the same API key or remove and re-add the integration."
     }
   },
@@ -128,6 +138,9 @@
       "temperature": {
         "name": "Temperature"
       },
+      "general_temperature": {
+        "name": "Temperature"
+      },
       "humidity": {
         "name": "Humidity"
       },
@@ -187,6 +200,12 @@
       }
     },
     "switch": {
+      "microphone": {
+        "name": "Microphone"
+      },
+      "privacy_mode": {
+        "name": "Privacy Mode"
+      },
       "status_light": {
         "name": "Status Light"
       },
@@ -198,6 +217,21 @@
       }
     },
     "select": {
+      "hdr_mode": {
+        "name": "HDR Mode"
+      },
+      "video_mode": {
+        "name": "Video Mode"
+      },
+      "ringtone": {
+        "name": "Ringtone"
+      },
+      "ptz_preset": {
+        "name": "PTZ Preset"
+      },
+      "liveview": {
+        "name": "Liveview"
+      },
       "recording_mode": {
         "name": "Recording Mode"
       },
@@ -209,11 +243,33 @@
       "mic_volume": {
         "name": "Microphone Volume"
       },
+      "brightness_level": {
+        "name": "Brightness Level"
+      },
       "speaker_volume": {
         "name": "Speaker Volume"
       },
       "chime_volume": {
         "name": "Chime Volume"
+      },
+      "repeat_times": {
+        "name": "Repeat Times"
+      }
+    },
+    "event": {
+      "doorbell_ring": {
+        "name": "Doorbell"
+      },
+      "smart_detection": {
+        "name": "Smart Detection"
+      },
+      "sensor_event": {
+        "name": "Door/Window"
+      }
+    },
+    "update": {
+      "firmware": {
+        "name": "Firmware"
       }
     }
   },

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -172,10 +172,11 @@ async def test_setup_entry_no_sites_found(
 async def test_setup_entry_remote_connection(
     hass: HomeAssistant,
     mock_network_client,
+    mock_protect_client,
     mock_local_auth,
     enable_custom_integrations,
 ) -> None:
-    """Test setup with remote connection type skips Protect."""
+    """Test setup with remote connection type includes Protect."""
     # Create remote config entry
     remote_entry = MockConfigEntry(
         domain="unifi_insights",

--- a/tests/test_vendored_api.py
+++ b/tests/test_vendored_api.py
@@ -34,7 +34,7 @@ def test_build_legacy_api_path_remote() -> None:
 
     assert (
         client.build_legacy_api_path("default", "stat/device/aa:bb:cc")
-        == "/v1/connector/consoles/console-id/proxy/network/api/s/default/"
+        == "/v1/connector/consoles/console-id/network/api/s/default/"
         "stat/device/aa:bb:cc"
     )
 
@@ -60,7 +60,7 @@ def test_build_legacy_global_api_path_remote() -> None:
 
     assert (
         client.build_legacy_global_api_path("/self/sites")
-        == "/v1/connector/consoles/console-id/proxy/network/api/self/sites"
+        == "/v1/connector/consoles/console-id/network/api/self/sites"
     )
 
 
@@ -125,7 +125,7 @@ async def test_get_legacy_device_stats_handles_wrapped_and_unwrapped_responses(
 
     assert result == expected
     client._get.assert_awaited_once_with(
-        "/v1/connector/consoles/console-id/proxy/network/api/s/default/"
+        "/v1/connector/consoles/console-id/network/api/s/default/"
         "stat/device/aa:bb:cc:dd:ee:ff"
     )
 


### PR DESCRIPTION
- Fix double /proxy/ prefix in remote connector paths for Network and Protect API clients (align with developer.ui.com Connector API docs)
- Enable Protect client creation for remote (cloud) connections in __init__.py — previously Protect was explicitly disabled for remote
- Remove spurious /sites/{siteId} from Protect remote paths (Protect API does not use site-scoped URLs)
- Update translations/en.json to include all missing config flow keys (fixes raw no_remote_consoles key shown in UI)
- Update tests for new remote path assertions and Protect client fixture
- Update api.instructions.md to reflect Protect works for both modes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remote connections now support UniFi Protect camera management alongside Network functionality.

* **Bug Fixes**
  * Fixed UniFi Remote Cloud authentication issue.
  * Corrected API path construction for remote connections.

* **Documentation**
  * Added console selection step in configuration workflow.
  * Expanded entity translations for cameras, sensors, and device controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->