### PR TITLE
Fix: Add VPN client type to ClientType enum

### DIFF
--- a/custom_components/unifi_insights/api/network/models/client.py
+++ b/custom_components/unifi_insights/api/network/models/client.py
@@ -18,6 +18,7 @@ class ClientType(str, Enum):
 
     WIRED = "WIRED"
     WIRELESS = "WIRELESS"
+    VPN = "VPN"
 
     @classmethod
     def _missing_(cls, value: object) -> ClientType | None:


### PR DESCRIPTION
## Summary

- The UniFi Network API returns clients with type `VPN` for site-to-site VPN and client VPN connections
- The `ClientType` enum only accepted `WIRED` and `WIRELESS`, causing a pydantic `ValidationError` on every device coordinator update (every 30 seconds)
- This crashed the entire client fetch, preventing all device/client data from being updated
- Over time, the repeated exception handling contributed to memory growth

## Changes

Added `VPN = "VPN"` to the `ClientType` enum in `custom_components/unifi_insights/api/network/models/client.py`.

The existing `_missing_` classmethod already handles case-insensitive lookup, so `vpn`/`Vpn` variants will also be handled.

## Error before fix

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for Client
type
  Input should be 'WIRED' or 'WIRELESS' [type=enum, input_value='VPN', input_type=str]
```

## Test plan

- [ ] Verify on a network with VPN clients: clients should be fetched without errors
- [ ] Verify WIRED and WIRELESS clients still work as before
- [ ] Verify the device coordinator no longer logs "Error processing site" every 30 seconds


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended network client type support to include VPN clients alongside existing wired and wireless device types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->