### PR TITLE
fix(api): raise on 2xx responses with a non-JSON body instead of swallowing them

### DIFF
--- a/custom_components/unifi_insights/api/base.py
+++ b/custom_components/unifi_insights/api/base.py
@@ -291,12 +291,25 @@ class BaseUniFiClient(ABC):
         try:
             data: dict[str, Any] | list[Any] = await response.json()
             return data
-        except (ValueError, aiohttp.ContentTypeError):
+        except (ValueError, aiohttp.ContentTypeError) as err:
+            # A 2xx status with a non-JSON body (e.g. an HTML login page from
+            # a proxy/console that considers the request unauthenticated) is
+            # not a successful empty response - treating it as one let this
+            # go completely unnoticed for 47h in production: no exception
+            # ever reached the coordinator, so `last_update_success` stayed
+            # True and entities kept serving stale cached data indefinitely
+            # instead of surfacing as unavailable and letting the
+            # coordinator's normal retry/backoff take over.
             redacted_response = (
                 _redact(response_text)[:200] if response_text else "empty"
             )
             _LOGGER.warning("Response is not JSON: %s", redacted_response)
-            return None
+            msg = f"API returned non-JSON response (status {status})"
+            raise UniFiResponseError(
+                msg,
+                status_code=status,
+                response_body=response_text,
+            ) from err
 
     async def _get(
         self,

--- a/tests/test_vendored_api.py
+++ b/tests/test_vendored_api.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
+import aiohttp
 import pytest
 
 from custom_components.unifi_insights.api import ApiKeyAuth, ConnectionType
+from custom_components.unifi_insights.api.exceptions import UniFiResponseError
 from custom_components.unifi_insights.api.network import UniFiNetworkClient
 from custom_components.unifi_insights.api.protect import UniFiProtectClient
 
@@ -867,3 +869,69 @@ async def test_devices_get_pending_adoption_skips_malformed_items() -> None:
 
     assert len(result) == 1
     assert result[0].id == "pend-1"
+def _make_response(*, status: int = 200, text: str = "", json_side_effect=None):
+    """Build a fake aiohttp.ClientResponse for _handle_response tests."""
+    response = MagicMock()
+    response.status = status
+    response.text = AsyncMock(return_value=text)
+    response.headers = {}
+    if json_side_effect is not None:
+        response.json = AsyncMock(side_effect=json_side_effect)
+    else:
+        response.json = AsyncMock(return_value={})
+    return response
+
+
+async def test_handle_response_2xx_non_json_raises() -> None:
+    """A 2xx status with a non-JSON body must raise, not be treated as success.
+
+    Regression test: a UniFi console/proxy that considers the request
+    unauthenticated can return a 2xx status with an HTML login page body.
+    Silently returning None here (the old behavior) meant no exception ever
+    reached the coordinator, so entities kept serving stale data for 47h in
+    production instead of surfacing as unavailable.
+    """
+    client = UniFiNetworkClient(
+        auth=ApiKeyAuth(api_key="test-key"),
+        base_url="https://192.168.1.1",
+        connection_type=ConnectionType.LOCAL,
+    )
+    response = _make_response(
+        status=200,
+        text="<!doctype html><html><body>login</body></html>",
+        json_side_effect=aiohttp.ContentTypeError(MagicMock(), MagicMock()),
+    )
+
+    with pytest.raises(UniFiResponseError) as exc_info:
+        await client._handle_response(response)
+
+    assert exc_info.value.status_code == 200
+
+
+async def test_handle_response_empty_body_returns_none() -> None:
+    """An empty 2xx body (e.g. a 204-style response) is still a valid no-op."""
+    client = UniFiNetworkClient(
+        auth=ApiKeyAuth(api_key="test-key"),
+        base_url="https://192.168.1.1",
+        connection_type=ConnectionType.LOCAL,
+    )
+    response = _make_response(status=200, text="")
+
+    result = await client._handle_response(response)
+
+    assert result is None
+
+
+async def test_handle_response_valid_json_returns_data() -> None:
+    """A normal JSON response still parses and returns as before."""
+    client = UniFiNetworkClient(
+        auth=ApiKeyAuth(api_key="test-key"),
+        base_url="https://192.168.1.1",
+        connection_type=ConnectionType.LOCAL,
+    )
+    response = _make_response(status=200, text='{"ok": true}')
+    response.json = AsyncMock(return_value={"ok": True})
+
+    result = await client._handle_response(response)
+
+    assert result == {"ok": True}


### PR DESCRIPTION
On a Protect-only UNVR-PRO console, 111 of 127 entities sat frozen for
about 47 hours with nothing logged. No errors, no unavailable entities,
`last_update_success` still True the whole time.

`_handle_response` in `api/base.py` catches `ContentTypeError`/`ValueError`
from `response.json()`. On any non-JSON body it returned `None`,
regardless of status code. A console or proxy that answers a 2xx with an
HTML login page (expired session redirected to a login screen) lands
exactly there. No exception ever reached the coordinator, so entities
kept serving stale cached data indefinitely instead of going unavailable
and letting the coordinator's normal retry and backoff take over.

The failure is silent, which is the worst part. Nothing in the UI or the
log indicates anything is wrong. I only found it because door sensors
stopped reflecting reality.

Fix: raise `UniFiResponseError(status_code=status, response_body=response_text)`
instead of returning `None`. That flows into the existing
`_handle_response_error` -> `UpdateFailed` path, which was already correct
but never triggered.

Verified: full suite, 1098 passed, 90.12% coverage (gate 90%). Three
tests cover it: a non-JSON 2xx body raises, an empty 2xx body still
returns `None` so 204-style responses stay valid, and a normal JSON body
still parses.

Risk is low. This only changes behaviour for a 2xx status carrying a body
that fails to parse as JSON, which is already treated as an error for
every status >= 400. No change to 4xx/5xx handling, and no change for a
genuinely empty body.
