### PR TITLE
fix(entity): gate Protect and Network entity availability on coordinator freshness

### DIFF
--- a/custom_components/unifi_insights/entity.py
+++ b/custom_components/unifi_insights/entity.py
@@ -205,6 +205,13 @@ class UnifiInsightsEntity(CoordinatorEntity[UnifiFacadeCoordinator]):
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
+        # Cached device data can still read "online" long after the
+        # coordinator has stopped getting fresh data from the API (see
+        # UnifiProtectEntity.available for the incident this mirrors) - the
+        # facade's own `available` reflects sub-coordinator
+        # last_update_success and must gate this too.
+        if not self.coordinator.available:
+            return False
         device_data = (
             self.coordinator.data["devices"].get(self._site_id, {}).get(self._device_id)
         )
@@ -215,6 +222,11 @@ class UnifiInsightsEntity(CoordinatorEntity[UnifiFacadeCoordinator]):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
+        if not self.coordinator.available:
+            self._attr_available = False
+            self.async_write_ha_state()
+            return
+
         device_data = (
             self.coordinator.data["devices"].get(self._site_id, {}).get(self._device_id)
         )
@@ -414,6 +426,15 @@ class UnifiProtectEntity(CoordinatorEntity[UnifiFacadeCoordinator]):
     @property
     def available(self) -> bool:
         """Return True if entity is available."""
+        # Cached protect device data keeps reporting the last-known
+        # "CONNECTED" state indefinitely once the protect coordinator stops
+        # getting fresh data (e.g. the NVR's local session periodically
+        # expiring) - this let entities serve frozen data for hours with no
+        # unavailable signal, invisible to HA and to the user, until an
+        # external reload forced a resync. Gate on the facade's own
+        # `available` (sub-coordinator last_update_success) first.
+        if not self.coordinator.available:
+            return False
         device_data = self.coordinator.data["protect"][f"{self._device_type}s"].get(
             self._device_id
         )
@@ -425,6 +446,11 @@ class UnifiProtectEntity(CoordinatorEntity[UnifiFacadeCoordinator]):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
+        if not self.coordinator.available:
+            self._attr_available = False
+            self.async_write_ha_state()
+            return
+
         device_data = self.device_data
         if not device_data:
             self._attr_available = False

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -257,6 +257,29 @@ class TestUnifiInsightsEntity:
 
         assert entity.available is False
 
+    async def test_entity_handle_coordinator_update_unavailable_then_recovers(
+        self, hass: HomeAssistant, mock_coordinator
+    ):
+        """Entity un-freezes on _handle_coordinator_update once coordinator recovers."""
+        description = EntityDescription(key="test", name="Test")
+        entity = UnifiInsightsEntity(
+            coordinator=mock_coordinator,
+            description=description,
+            site_id="site1",
+            device_id="device1",  # cached state is ONLINE
+        )
+        entity.async_write_ha_state = MagicMock()
+
+        mock_coordinator.available = False
+        entity._handle_coordinator_update()
+        assert entity._attr_available is False
+        assert entity.available is False
+
+        mock_coordinator.available = True
+        entity._handle_coordinator_update()
+        assert entity._attr_available is True
+        assert entity.available is True
+
     async def test_entity_device_data(self, hass: HomeAssistant, mock_coordinator):
         """Test entity device_data property."""
         description = EntityDescription(key="test", name="Test")
@@ -451,6 +474,28 @@ class TestUnifiProtectEntity:
         )
 
         assert entity.available is False
+
+    async def test_protect_entity_handle_coordinator_update_unavailable_then_recovers(
+        self, hass: HomeAssistant, mock_coordinator
+    ):
+        """Protect entity un-freezes on coordinator update once coordinator recovers."""
+        entity = UnifiProtectEntity(
+            coordinator=mock_coordinator,
+            device_type=DEVICE_TYPE_CAMERA,
+            device_id="camera1",  # cached state is CONNECTED
+        )
+        entity.async_write_ha_state = MagicMock()
+        entity._update_from_data = MagicMock()
+
+        mock_coordinator.available = False
+        entity._handle_coordinator_update()
+        assert entity._attr_available is False
+        assert entity.available is False
+
+        mock_coordinator.available = True
+        entity._handle_coordinator_update()
+        assert entity._attr_available is True
+        assert entity.available is True
 
     async def test_protect_entity_coordinator_update_refreshes_state(
         self, hass: HomeAssistant, mock_coordinator

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -241,6 +241,22 @@ class TestUnifiInsightsEntity:
 
         assert entity.available is False
 
+    async def test_entity_available_coordinator_unavailable(
+        self, hass: HomeAssistant, mock_coordinator
+    ):
+        """Entity unavailable when coordinator stale, even w/ cached ONLINE data."""
+        mock_coordinator.available = False
+        description = EntityDescription(key="test", name="Test")
+
+        entity = UnifiInsightsEntity(
+            coordinator=mock_coordinator,
+            description=description,
+            site_id="site1",
+            device_id="device1",  # cached state is ONLINE
+        )
+
+        assert entity.available is False
+
     async def test_entity_device_data(self, hass: HomeAssistant, mock_coordinator):
         """Test entity device_data property."""
         description = EntityDescription(key="test", name="Test")
@@ -418,6 +434,20 @@ class TestUnifiProtectEntity:
             coordinator=mock_coordinator,
             device_type=DEVICE_TYPE_CAMERA,
             device_id="camera2",
+        )
+
+        assert entity.available is False
+
+    async def test_protect_entity_available_coordinator_unavailable(
+        self, hass: HomeAssistant, mock_coordinator
+    ):
+        """Protect entity unavailable when coordinator stale (mirrors 47h incident)."""
+        mock_coordinator.available = False
+
+        entity = UnifiProtectEntity(
+            coordinator=mock_coordinator,
+            device_type=DEVICE_TYPE_CAMERA,
+            device_id="camera1",  # cached state is CONNECTED
         )
 
         assert entity.available is False


### PR DESCRIPTION
`UnifiProtectEntity.available` and `UnifiInsightsEntity.available` only look at the cached device `state` field. Neither one consults `coordinator.available`.

That matters once a coordinator starts failing. On my UNVR-PRO the Protect coordinator periodically loses its local session; the poll fails, but every entity keeps reporting `available=True` from the last cached payload. Home Assistant shows a door as `closed` with no indication that the reading is hours old. The facade coordinator already tracks `last_update_success` on each sub-coordinator correctly, so the information is there, it just isn't consulted.

This gates `available` and `_handle_coordinator_update` on `self.coordinator.available` first, in both entity base classes.

Tests cover both directions: entities go unavailable when the coordinator fails, and become available again when it recovers. The recovery case matters, because a one-way gate would pin everything unavailable after a single transient failure.
