### PR TITLE
fix(coordinators): release facade listeners on shutdown, make async_request_refresh actually refresh

### DIFF
--- a/custom_components/unifi_insights/coordinators/facade.py
+++ b/custom_components/unifi_insights/coordinators/facade.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime
 import logging
 from typing import TYPE_CHECKING, Any
@@ -74,6 +75,11 @@ class UnifiFacadeCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._device_coordinator = device_coordinator
         self._protect_coordinator = protect_coordinator
 
+        # Remove-callbacks returned by async_add_listener() below, released
+        # in async_shutdown() so this facade's forwarding listener doesn't
+        # outlive it on the sub-coordinators (see _setup_listeners).
+        self._sub_coordinator_unsubs: list[Callable[[], None]] = []
+
         # Register listeners to update when any coordinator updates
         self._setup_listeners()
 
@@ -83,13 +89,50 @@ class UnifiFacadeCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
     def _setup_listeners(self) -> None:
         """Set up listeners to aggregate data when coordinators update."""
-        # When device coordinator updates, trigger facade update
-        self._device_coordinator.async_add_listener(self._handle_coordinator_update)
-        self._config_coordinator.async_add_listener(self._handle_coordinator_update)
+        # async_add_listener() returns a remove-callback; it must be kept
+        # and invoked on shutdown (see async_shutdown) or this facade's
+        # listener registration outlives the facade itself - each
+        # config-entry reload builds a fresh facade + fresh sub-coordinators,
+        # but without releasing this, the outgoing facade stays reachable
+        # (and un-collectable) via the very listener slot it never freed.
+        self._sub_coordinator_unsubs.append(
+            self._device_coordinator.async_add_listener(self._handle_coordinator_update)
+        )
+        self._sub_coordinator_unsubs.append(
+            self._config_coordinator.async_add_listener(self._handle_coordinator_update)
+        )
         if self._protect_coordinator:
-            self._protect_coordinator.async_add_listener(
-                self._handle_coordinator_update
+            self._sub_coordinator_unsubs.append(
+                self._protect_coordinator.async_add_listener(
+                    self._handle_coordinator_update
+                )
             )
+
+    async def async_shutdown(self) -> None:
+        """
+        Shut down the facade and release its listeners on the sub-coordinators.
+
+        ``DataUpdateCoordinator.__init__`` auto-registers
+        ``config_entry.async_on_unload(self.async_shutdown)`` for every
+        coordinator constructed with a ``config_entry`` (all four of ours
+        qualify), so this already runs automatically on config-entry
+        unload/reload - no extra wiring is needed in
+        ``__init__.py::async_unload_entry``. That auto-registration is also
+        why a leaked facade doesn't keep the sub-coordinators *polling*:
+        each sub-coordinator's own auto-registered ``async_shutdown()``
+        cancels its scheduled refresh and sets ``_shutdown_requested``,
+        which ``_async_refresh()`` checks before it would ever fetch or
+        reschedule. What that auto-registration does *not* do is undo the
+        side effect *this* facade caused on *other* objects: the base
+        ``async_shutdown()`` never touches ``_listeners``, so the
+        remove-callbacks from ``_setup_listeners`` must be released here
+        explicitly, or the sub-coordinators keep a dead reference back to
+        this facade indefinitely.
+        """
+        for unsub in self._sub_coordinator_unsubs:
+            unsub()
+        self._sub_coordinator_unsubs.clear()
+        await super().async_shutdown()
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -171,14 +214,54 @@ class UnifiFacadeCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         return self.data
 
     async def async_request_refresh(self) -> None:
-        """Request refresh of all underlying coordinators."""
-        # Refresh all coordinators
-        await self._config_coordinator.async_request_refresh()
-        await self._device_coordinator.async_request_refresh()
+        """
+        Force a genuine refresh of all underlying coordinators and notify listeners.
+
+        Entity action handlers (see switch.py) call this right after a
+        mutating API call and expect the coordinator to reflect the change
+        by the time the await returns. Two deliberate departures from the
+        obvious implementation make that true:
+
+        1. Each sub-coordinator's own ``async_refresh()`` is used instead
+           of its ``async_request_refresh()``. The latter goes through
+           that coordinator's ``Debouncer`` - fine for coalescing
+           coordinator-internal refresh triggers, but wrong here: when a
+           debounce cooldown from unrelated recent activity is already
+           armed, ``async_request_refresh()`` returns immediately without
+           fetching anything, so aggregating right after it would silently
+           serve stale data. ``async_refresh()`` always performs (and
+           awaits) a real fetch. The trade-off is that this path no longer
+           benefits from that debounce - acceptable because it only runs
+           once per explicit, user-triggered action, not on a hot loop.
+        2. The three refreshes run concurrently via ``asyncio.gather``
+           rather than sequentially - three real HTTP round trips awaited
+           one after another would make every action handler noticeably
+           slower for no benefit, since the coordinators are independent.
+
+        Each sub-coordinator's own refresh already calls
+        ``async_update_listeners()`` when its data changes, which cascades
+        into this facade's ``_handle_coordinator_update`` via the listener
+        chain from ``_setup_listeners`` - re-aggregating and notifying
+        this facade's listeners already in the common case. The explicit
+        ``_aggregate_data()`` + ``async_update_listeners()`` below is kept
+        anyway so a caller of this method is *always* notified even in the
+        edge case where none of the three sub-refreshes produced a change
+        (so that cascade stays silent) - the base
+        ``DataUpdateCoordinator.async_request_refresh()`` this replaces
+        never called ``async_update_listeners()`` at all, which was the
+        second half of the original defect.
+        """
+        refresh_tasks = [
+            self._config_coordinator.async_refresh(),
+            self._device_coordinator.async_refresh(),
+        ]
         if self._protect_coordinator:
-            await self._protect_coordinator.async_request_refresh()
-        # Aggregate the updated data
+            refresh_tasks.append(self._protect_coordinator.async_refresh())
+        await asyncio.gather(*refresh_tasks)
+
+        # Aggregate the updated data and notify this facade's own listeners.
         self._aggregate_data()
+        self.async_update_listeners()
 
     def _require_protect_client(self) -> UniFiProtectClient:
         """Return the Protect client or raise a user-facing error."""

--- a/tests/test_coordinators.py
+++ b/tests/test_coordinators.py
@@ -2134,33 +2134,92 @@ class TestUnifiFacadeCoordinator:
     async def test_async_request_refresh(
         self, facade_coordinator: UnifiFacadeCoordinator
     ):
-        """Test async request refresh."""
-        facade_coordinator._config_coordinator.async_request_refresh = AsyncMock()
-        facade_coordinator._device_coordinator.async_request_refresh = AsyncMock()
-        facade_coordinator._protect_coordinator.async_request_refresh = AsyncMock()
+        """
+        Test async_request_refresh forces a genuine refresh on each
+        sub-coordinator (async_refresh), not the debounced
+        async_request_refresh which can return before any fetch happens.
+        """
+        facade_coordinator._config_coordinator.async_refresh = AsyncMock()
+        facade_coordinator._device_coordinator.async_refresh = AsyncMock()
+        facade_coordinator._protect_coordinator.async_refresh = AsyncMock()
 
         await facade_coordinator.async_request_refresh()
 
-        facade_coordinator._config_coordinator.async_request_refresh.assert_called_once()
-        facade_coordinator._device_coordinator.async_request_refresh.assert_called_once()
-        facade_coordinator._protect_coordinator.async_request_refresh.assert_called_once()
+        facade_coordinator._config_coordinator.async_refresh.assert_called_once()
+        facade_coordinator._device_coordinator.async_refresh.assert_called_once()
+        facade_coordinator._protect_coordinator.async_refresh.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_async_request_refresh_no_protect(
         self, facade_coordinator_no_protect: UnifiFacadeCoordinator
     ):
         """Test async request refresh without protect."""
-        facade_coordinator_no_protect._config_coordinator.async_request_refresh = (
-            AsyncMock()
-        )
-        facade_coordinator_no_protect._device_coordinator.async_request_refresh = (
-            AsyncMock()
-        )
+        facade_coordinator_no_protect._config_coordinator.async_refresh = AsyncMock()
+        facade_coordinator_no_protect._device_coordinator.async_refresh = AsyncMock()
 
         await facade_coordinator_no_protect.async_request_refresh()
 
-        facade_coordinator_no_protect._config_coordinator.async_request_refresh.assert_called_once()
-        facade_coordinator_no_protect._device_coordinator.async_request_refresh.assert_called_once()
+        facade_coordinator_no_protect._config_coordinator.async_refresh.assert_called_once()
+        facade_coordinator_no_protect._device_coordinator.async_refresh.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_async_request_refresh_waits_for_fresh_data_and_notifies(
+        self, facade_coordinator: UnifiFacadeCoordinator
+    ):
+        """
+        Regression test for the async_request_refresh contract violation.
+
+        Callers (e.g. switch.py action handlers) await
+        ``coordinator.async_request_refresh()`` expecting two things: (1)
+        the aggregated data reflects a fetch that actually happened during
+        the call, and (2) their own listener gets notified. The previous
+        implementation awaited each sub-coordinator's *debounced*
+        ``async_request_refresh()``, which can return before any fetch
+        starts (see ``Debouncer`` cooldown), and never called
+        ``async_update_listeners()`` itself - so both guarantees could be
+        silently violated.
+
+        This test drives a real (mocked) async_refresh that mutates the
+        sub-coordinator's data, then asserts the facade's aggregated data
+        reflects it and that a registered listener was actually called.
+        """
+        listener_calls = 0
+
+        def listener() -> None:
+            nonlocal listener_calls
+            listener_calls += 1
+
+        facade_coordinator.async_add_listener(listener)
+
+        async def _fake_refresh() -> None:
+            facade_coordinator._config_coordinator.data["sites"] = {
+                "new-site": {"id": "new-site"}
+            }
+
+        facade_coordinator._config_coordinator.async_refresh = AsyncMock(
+            side_effect=_fake_refresh
+        )
+        facade_coordinator._device_coordinator.async_refresh = AsyncMock()
+        facade_coordinator._protect_coordinator.async_refresh = AsyncMock()
+        # The debounced path must not be used for this explicit,
+        # user-triggered refresh - assert it's never touched.
+        facade_coordinator._config_coordinator.async_request_refresh = AsyncMock()
+        facade_coordinator._device_coordinator.async_request_refresh = AsyncMock()
+        facade_coordinator._protect_coordinator.async_request_refresh = AsyncMock()
+
+        await facade_coordinator.async_request_refresh()
+
+        facade_coordinator._config_coordinator.async_request_refresh.assert_not_called()
+        facade_coordinator._device_coordinator.async_request_refresh.assert_not_called()
+        facade_coordinator._protect_coordinator.async_request_refresh.assert_not_called()
+
+        # The aggregated data must reflect what the (mocked) genuine
+        # refresh produced, proving the call actually waited for it.
+        assert facade_coordinator.data["sites"] == {"new-site": {"id": "new-site"}}
+
+        # Listeners (entities) must be notified so they can reflect the
+        # refreshed state without waiting for the next natural poll.
+        assert listener_calls >= 1
 
     def test_handle_coordinator_update(
         self, facade_coordinator: UnifiFacadeCoordinator
@@ -2607,6 +2666,39 @@ class TestUnifiFacadeCoordinator:
             await coord.async_play_chime("chime1")
         with pytest.raises(HomeAssistantError, match="Protect is not available"):
             await coord.async_trigger_alarm("alarm1")
+
+    @pytest.mark.asyncio
+    async def test_async_shutdown_releases_sub_coordinator_listeners(
+        self,
+        facade_coordinator: UnifiFacadeCoordinator,
+        config_coordinator: UnifiConfigCoordinator,
+        device_coordinator: UnifiDeviceCoordinator,
+        protect_coordinator: UnifiProtectCoordinator,
+    ):
+        """
+        Regression test for the sub-coordinator listener leak.
+
+        ``_setup_listeners`` registers the facade as a listener on each
+        sub-coordinator via ``async_add_listener``, which returns a
+        remove-callback. Discarding that callback (the previous behavior)
+        means nothing ever undoes the registration: on config-entry
+        reload, a fresh facade is built and a fresh listener piles onto
+        the sub-coordinators, while the outgoing facade instance and its
+        listener registration are never released. Shutting the facade
+        down must release exactly what it registered, returning each
+        sub-coordinator's listener count to its pre-facade baseline.
+        """
+        # Baseline: __init__ -> _setup_listeners already registered
+        # exactly one listener (this facade) on each sub-coordinator.
+        assert len(config_coordinator._listeners) == 1
+        assert len(device_coordinator._listeners) == 1
+        assert len(protect_coordinator._listeners) == 1
+
+        await facade_coordinator.async_shutdown()
+
+        assert len(config_coordinator._listeners) == 0
+        assert len(device_coordinator._listeners) == 0
+        assert len(protect_coordinator._listeners) == 0
 
 
 # ============================================================================

--- a/tests/test_coordinators.py
+++ b/tests/test_coordinators.py
@@ -2700,6 +2700,39 @@ class TestUnifiFacadeCoordinator:
         assert len(device_coordinator._listeners) == 0
         assert len(protect_coordinator._listeners) == 0
 
+    async def test_async_shutdown_is_idempotent(
+        self,
+        facade_coordinator: UnifiFacadeCoordinator,
+    ):
+        """
+        Shutting the facade down twice must be safe.
+
+        ``DataUpdateCoordinator.__init__`` registers
+        ``entry.async_on_unload(self.async_shutdown)``, so HA invokes
+        shutdown on its own at unload -- which can coincide with an
+        explicit call from our unload path. The second pass must not
+        raise and must not re-invoke the already-spent remove-callbacks
+        (which would unregister listeners belonging to a *newer* facade
+        built by the reload that followed).
+        """
+        # Stand in for the real remove-callbacks so a second release is
+        # observable. Listener-count behavior is covered by
+        # test_async_shutdown_releases_sub_coordinator_listeners.
+        unsubs = [MagicMock() for _ in range(3)]
+        facade_coordinator._sub_coordinator_unsubs = list(unsubs)
+
+        await facade_coordinator.async_shutdown()
+        for unsub in unsubs:
+            assert unsub.call_count == 1
+
+        # Second shutdown: must not raise, and must not re-invoke the
+        # already-spent callbacks.
+        await facade_coordinator.async_shutdown()
+        for unsub in unsubs:
+            assert unsub.call_count == 1
+
+        assert facade_coordinator._sub_coordinator_unsubs == []
+
 
 # ============================================================================
 # Integration Tests for Coordinator Data Flow


### PR DESCRIPTION
Two problems in `UnifiFacadeCoordinator`, both found while looking at reload behaviour.

### Listener leak

`_setup_listeners()` discards the remove-callbacks that `async_add_listener()` returns, so a reloaded facade never releases its registration on the sub-coordinators. It doesn't surface as duplicate polling: `DataUpdateCoordinator.__init__` registers `config_entry.async_on_unload(self.async_shutdown)`, and each sub-coordinator's own shutdown cancels its scheduled refresh. But the dead facade stays referenced by the live sub-coordinators for the life of the process, and its `_handle_sub_coordinator_update` keeps running.

The fix stores the callbacks and releases them in an `async_shutdown()` override, which HA already invokes on unload.

### `async_request_refresh` contract

It awaited each sub-coordinator's *debounced* `async_request_refresh()`, which can return before any fetch happens, then aggregated and returned without calling `async_update_listeners()`. An entity action handler that awaits this expecting fresh, notified state could get neither.

It now runs `async_refresh()` on the sub-coordinators concurrently, deliberately bypassing the debounce since this only runs once per user action, then aggregates and notifies explicitly.

### Tests

Written test-first. `test_async_shutdown_releases_sub_coordinator_listeners` and `test_async_request_refresh_waits_for_fresh_data_and_notifies` fail on main and pass here, and the two existing `async_request_refresh` tests are updated to the new contract.

A third test covers shutdown idempotency. HA's auto-registration means shutdown can be invoked on its own at unload, possibly at the same time as an explicit call, and re-invoking spent callbacks would unregister listeners belonging to the newer facade built by the following reload. That invariant was reasoned about in a docstring but never asserted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Explicit refreshes now reliably fetch the latest data and update displayed information.
  * Refresh results are delivered concurrently for faster updates.
  * Registered listeners are properly released during shutdown.
  * Repeated shutdowns are handled safely without errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->