### PR TITLE
fix(protect): wire up the Protect WebSocket so entities update in real time

### DIFF
--- a/custom_components/unifi_insights/__init__.py
+++ b/custom_components/unifi_insights/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from dataclasses import dataclass
 import logging
 from typing import TYPE_CHECKING, TypeAlias
@@ -310,6 +311,14 @@ async def async_setup_entry(
     )
 
     # 3. Protect coordinator - fast updates (30 seconds) + WebSocket for events
+    # WebSocket site_id: LOCAL consoles ignore site_id for the Protect REST/WS
+    # paths, so "default" is fine. REMOTE (cloud connector) routing uses the
+    # console_id embedded in the path, but if the Network API returned sites
+    # for this console, prefer the first real site id over the placeholder.
+    protect_site_id = "default"
+    if not is_local and network_available and sites:
+        protect_site_id = sites[0].id
+
     protect_coordinator: UnifiProtectCoordinator | None = None
     if protect_client:
         protect_coordinator = UnifiProtectCoordinator(
@@ -317,6 +326,7 @@ async def async_setup_entry(
             network_client=network_client,
             protect_client=protect_client,
             entry=entry,
+            site_id=protect_site_id,
         )
 
     # Fetch initial data - config first, then device/protect in parallel
@@ -328,6 +338,12 @@ async def async_setup_entry(
     if protect_coordinator:
         refresh_tasks.append(protect_coordinator.async_config_entry_first_refresh())
     await asyncio.gather(*refresh_tasks)
+
+    # Start the real-time Protect WebSocket subscription (additive to the
+    # 30s poll above, which stays as the fallback - see
+    # UnifiProtectCoordinator.async_start_websocket).
+    if protect_coordinator:
+        await protect_coordinator.async_start_websocket()
 
     # Create facade coordinator for backward compatibility with entity classes
     # (it aggregates the initial data from the sub-coordinators on creation)
@@ -378,13 +394,27 @@ async def async_unload_entry(
         data = entry.runtime_data
         _LOGGER.debug("Closing API clients")
         if data.protect_client:
-            # Stop WebSocket if active (on protect coordinator)
+            # Stop WebSocket if active (on protect coordinator). Signal the
+            # ProtectWebSocket loop to stop reconnecting *before* cancelling
+            # the task, then await the cancellation - cancel() alone leaves
+            # the reconnect loop free to spin back up, and the loop being
+            # parked in `async for msg in ws` means stop() alone won't
+            # unblock it either; both are needed to avoid an orphaned
+            # WebSocket loop surviving a config entry reload.
             if data.protect_coordinator:
+                protect_websocket = getattr(
+                    data.protect_coordinator, "_protect_websocket", None
+                )
+                if protect_websocket:
+                    protect_websocket.stop()
                 websocket_task = getattr(
                     data.protect_coordinator, "websocket_task", None
                 )
                 if websocket_task:
                     websocket_task.cancel()
+                    if isinstance(websocket_task, asyncio.Task):
+                        with contextlib.suppress(asyncio.CancelledError, Exception):
+                            await websocket_task
             # Close Protect client (await the async close)
             try:
                 await data.protect_client.close()

--- a/custom_components/unifi_insights/__init__.py
+++ b/custom_components/unifi_insights/__init__.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 from dataclasses import dataclass
 import logging
 from typing import TYPE_CHECKING, TypeAlias
@@ -341,9 +340,13 @@ async def async_setup_entry(
 
     # Start the real-time Protect WebSocket subscription (additive to the
     # 30s poll above, which stays as the fallback - see
-    # UnifiProtectCoordinator.async_start_websocket).
+    # UnifiProtectCoordinator.async_start_websocket). Registered for
+    # on-unload cleanup immediately so a setup failure later in this
+    # function (e.g. platform forwarding below) can't leak the background
+    # task - HA still runs async_on_unload callbacks when setup fails.
     if protect_coordinator:
         await protect_coordinator.async_start_websocket()
+        entry.async_on_unload(protect_coordinator.async_stop_websocket)
 
     # Create facade coordinator for backward compatibility with entity classes
     # (it aggregates the initial data from the sub-coordinators on creation)
@@ -394,27 +397,17 @@ async def async_unload_entry(
         data = entry.runtime_data
         _LOGGER.debug("Closing API clients")
         if data.protect_client:
-            # Stop WebSocket if active (on protect coordinator). Signal the
-            # ProtectWebSocket loop to stop reconnecting *before* cancelling
-            # the task, then await the cancellation - cancel() alone leaves
-            # the reconnect loop free to spin back up, and the loop being
-            # parked in `async for msg in ws` means stop() alone won't
-            # unblock it either; both are needed to avoid an orphaned
-            # WebSocket loop surviving a config entry reload.
+            # Stop the WebSocket (and await its background task) *before*
+            # closing the client below - stopping it after would leave the
+            # loop trying to use an already-closed session for whatever
+            # brief window passes before entry.async_on_unload's registered
+            # copy of this same call runs (see async_setup_entry - that
+            # registration is the safety net for a setup failure that
+            # happens after the WebSocket starts but before this function
+            # ever runs; async_stop_websocket() is idempotent so running it
+            # twice on a normal unload is harmless).
             if data.protect_coordinator:
-                protect_websocket = getattr(
-                    data.protect_coordinator, "_protect_websocket", None
-                )
-                if protect_websocket:
-                    protect_websocket.stop()
-                websocket_task = getattr(
-                    data.protect_coordinator, "websocket_task", None
-                )
-                if websocket_task:
-                    websocket_task.cancel()
-                    if isinstance(websocket_task, asyncio.Task):
-                        with contextlib.suppress(asyncio.CancelledError, Exception):
-                            await websocket_task
+                await data.protect_coordinator.async_stop_websocket()
             # Close Protect client (await the async close)
             try:
                 await data.protect_client.close()

--- a/custom_components/unifi_insights/api/protect/websocket.py
+++ b/custom_components/unifi_insights/api/protect/websocket.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any
@@ -12,6 +13,8 @@ import aiohttp
 
 if TYPE_CHECKING:
     from .client import UniFiProtectClient
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class ProtectWebSocket:
@@ -23,6 +26,13 @@ class ProtectWebSocket:
     To use WebSocket subscriptions, you need a `host_id` and `site_id`:
     - `host_id`: The NVR ID, obtainable via `await client.get_host_id()`
     - `site_id`: For local connections, use "default". For remote, get from cloud API.
+
+    `host_id`/`site_id` are accepted for API compatibility and potential future
+    multi-site routing, but the subscribe path is currently built the same way
+    as every other Protect endpoint - via `client.build_api_path()` - so that it
+    honours LOCAL (`/proxy/protect/integration/v1/subscribe/...`) vs REMOTE
+    (`/v1/connector/consoles/{console_id}/protect/integration/v1/subscribe/...`)
+    routing consistently with the REST endpoints on this client.
 
     Example:
         ```python
@@ -50,9 +60,17 @@ class ProtectWebSocket:
         self._ws: aiohttp.ClientWebSocketResponse | None = None
         self._running = False
 
-    async def _connect(
-        self, path: str
-    ) -> aiohttp.ClientWebSocketResponse:  # pragma: no cover
+    def _subscribe_path(self, subscription_type: str) -> str:
+        """
+        Build the subscribe path for the given subscription type.
+
+        Uses the same `build_api_path()` convention as every other Protect
+        endpoint on this client, so LOCAL and REMOTE connections are routed
+        correctly (see class docstring).
+        """
+        return self._client.build_api_path(f"/subscribe/{subscription_type}")
+
+    async def _connect(self, path: str) -> aiohttp.ClientWebSocketResponse:
         """
         Establish WebSocket connection.
 
@@ -92,7 +110,7 @@ class ProtectWebSocket:
                     print(f"Device update: {update}")
 
         """
-        path = f"/ea/hosts/{host_id}/sites/{site_id}/subscribe/devices"
+        path = self._subscribe_path("devices")
         ws = await self._connect(path)
         self._running = True
 
@@ -141,7 +159,7 @@ class ProtectWebSocket:
                     print(f"Event: {event}")
 
         """
-        path = f"/ea/hosts/{host_id}/sites/{site_id}/subscribe/events"
+        path = self._subscribe_path("events")
         ws = await self._connect(path)
         self._running = True
 
@@ -193,14 +211,20 @@ class ProtectWebSocket:
         if subscription_type not in ("devices", "events"):
             raise ValueError("subscription_type must be 'devices' or 'events'")
 
-        self._running = True  # pragma: no cover
+        path = self._subscribe_path(subscription_type)
+        self._running = True
 
-        while self._running:  # pragma: no cover
+        while self._running:
+            ws: aiohttp.ClientWebSocketResponse | None = None
             try:
-                path = (
-                    f"/ea/hosts/{host_id}/sites/{site_id}/subscribe/{subscription_type}"
-                )
                 ws = await self._connect(path)
+                _LOGGER.debug(
+                    "ProtectWebSocket: connected for %s subscription (host_id=%s, "
+                    "site_id=%s)",
+                    subscription_type,
+                    host_id,
+                    site_id,
+                )
 
                 async for msg in ws:
                     if not self._running:
@@ -210,18 +234,32 @@ class ProtectWebSocket:
                             data = json.loads(msg.data)
                             callback(data)
                         except json.JSONDecodeError:
+                            _LOGGER.debug(
+                                "ProtectWebSocket: dropped non-JSON message"
+                            )
                             continue
                     elif msg.type in (
                         aiohttp.WSMsgType.ERROR,
                         aiohttp.WSMsgType.CLOSED,
                     ):
                         break
-
-                await ws.close()
-
-            except (aiohttp.ClientError, asyncio.CancelledError):
-                # Expected during disconnects or cancellations; allow reconnection logic below
-                pass
+            except asyncio.CancelledError:
+                # Cancellation must propagate so the owning task actually
+                # stops instead of silently looping into a reconnect below.
+                raise
+            except aiohttp.ClientError as err:
+                # Expected during disconnects; log so a hardware/URL problem
+                # is visible instead of a silent reconnect loop, then allow
+                # the reconnection logic below to run.
+                _LOGGER.warning(
+                    "ProtectWebSocket: connection error subscribing to %s at %s: %s",
+                    subscription_type,
+                    path,
+                    err,
+                )
+            finally:
+                if ws is not None and not ws.closed:
+                    await ws.close()
 
             if self._running and reconnect:
                 await asyncio.sleep(reconnect_delay)

--- a/custom_components/unifi_insights/coordinators/protect.py
+++ b/custom_components/unifi_insights/coordinators/protect.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 from datetime import UTC, datetime
 import logging
 from typing import TYPE_CHECKING, Any
@@ -31,8 +33,6 @@ from custom_components.unifi_insights.const import (
 from .base import UnifiBaseCoordinator
 
 if TYPE_CHECKING:
-    import asyncio
-
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
 
@@ -110,6 +110,10 @@ class UnifiProtectCoordinator(UnifiBaseCoordinator):
         self._protect_websocket: Any = (
             self.protect_client.websocket if self.protect_client else None
         )
+        # Caps the "can't parse WebSocket message" warning to once, so a
+        # persistently wrong frame shape can't log-storm a production
+        # instance; every subsequent occurrence still logs at debug.
+        self._ws_parse_warned = False
 
     async def async_start_websocket(self) -> None:
         """
@@ -155,36 +159,94 @@ class UnifiProtectCoordinator(UnifiBaseCoordinator):
             self._site_id,
         )
 
+    async def async_stop_websocket(self) -> None:
+        """
+        Stop the WebSocket subscription and await its background task.
+
+        Safe to call when the WebSocket was never started. Signals the
+        `ProtectWebSocket` loop to stop reconnecting *before* cancelling the
+        task, then awaits the cancellation - `cancel()` alone leaves the
+        reconnect loop free to spin back up, and the loop being parked in
+        `async for msg in ws` means `stop()` alone won't unblock it either;
+        both are needed to avoid an orphaned WebSocket loop.
+
+        Registered with `entry.async_on_unload()` (covers a setup failure
+        that happens after the WebSocket started but before setup
+        completes) and also called directly from `async_unload_entry`'s
+        normal unload path.
+        """
+        if self._protect_websocket:
+            self._protect_websocket.stop()
+        task = self.websocket_task
+        if task:
+            task.cancel()
+            if isinstance(task, asyncio.Task):
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await task
+
     @callback
     def _on_websocket_message(self, message: dict[str, Any]) -> None:
         """
         Adapt a raw WebSocket "devices" message to `_handle_device_update`.
 
-        The message may carry the device fields at the top level or nested
-        under a "payload" key, and the model key may be `modelKey` (API
-        camelCase) or `model_key`. Anything that doesn't parse is logged at
-        warning level rather than dropped silently, since a swallowed frame
-        here is a missed device state change (e.g. a door sensor opening).
+        The exact wire shape for this API is not verified against hardware
+        (see AGENTS.md / commit message), so `modelKey` and `id` are each
+        resolved independently across every plausible container - top level,
+        a "payload" key (REST-response-shaped push), and an "action" key
+        (the header/payload split used by UniFi's private app WebSocket) -
+        rather than picking one container and giving up. Picking a single
+        container wrong would silently drop every real frame, which for a
+        door sensor means a missed open/close event.
         """
         if not isinstance(message, dict):
-            _LOGGER.warning(
+            self._log_unparseable_ws_message(
                 "Protect coordinator: WebSocket message was not a JSON object: %r",
                 message,
             )
             return
 
+        action = message.get("action")
         payload = message.get("payload")
-        device_data = payload if isinstance(payload, dict) else message
+        containers = [c for c in (payload, action, message) if isinstance(c, dict)]
 
-        model_key = device_data.get("modelKey") or device_data.get("model_key")
+        def _pick(key_camel: str, key_snake: str) -> Any:
+            for container in containers:
+                value = container.get(key_camel) or container.get(key_snake)
+                if value:
+                    return value
+            return None
+
+        model_key = _pick("modelKey", "model_key")
         if not model_key:
-            _LOGGER.warning(
+            self._log_unparseable_ws_message(
                 "Protect coordinator: WebSocket device message missing modelKey: %s",
                 message,
             )
             return
 
+        device_id = _pick("id", "id")
+        if not device_id:
+            _LOGGER.debug(
+                "Protect coordinator: WebSocket %s update missing device id: %s",
+                model_key,
+                message,
+            )
+            return
+
+        # Merge every dict container so fields split across payload/action
+        # (e.g. id in the header, state fields in the payload) are all kept.
+        device_data: dict[str, Any] = {}
+        for container in reversed(containers):
+            device_data.update(container)
+        device_data["id"] = device_id
+
         self._handle_device_update(model_key, device_data)
+
+    def _log_unparseable_ws_message(self, msg: str, *args: Any) -> None:
+        """Log an unparseable WS message once at WARNING, then at DEBUG."""
+        level = logging.WARNING if not self._ws_parse_warned else logging.DEBUG
+        _LOGGER.log(level, msg, *args)
+        self._ws_parse_warned = True
 
     @callback
     def _handle_device_update(

--- a/custom_components/unifi_insights/coordinators/protect.py
+++ b/custom_components/unifi_insights/coordinators/protect.py
@@ -189,14 +189,15 @@ class UnifiProtectCoordinator(UnifiBaseCoordinator):
         """
         Adapt a raw WebSocket "devices" message to `_handle_device_update`.
 
-        The exact wire shape for this API is not verified against hardware
-        (see AGENTS.md / commit message), so `modelKey` and `id` are each
-        resolved independently across every plausible container - top level,
-        a "payload" key (REST-response-shaped push), and an "action" key
-        (the header/payload split used by UniFi's private app WebSocket) -
-        rather than picking one container and giving up. Picking a single
-        container wrong would silently drop every real frame, which for a
-        door sensor means a missed open/close event.
+        Confirmed live against hardware 2026-08-12: the local-console shape is
+        `{"type": "update", "item": {"id", "modelKey", ...fields}}` - the
+        device delta lives under an "item" key, not at top level. `modelKey`
+        and `id` are still resolved independently across every plausible
+        container - "item", a "payload" key (REST-response-shaped push), and
+        an "action" key (the header/payload split used by UniFi's private
+        app WebSocket) - rather than picking one container and giving up.
+        Picking a single container wrong would silently drop every real
+        frame, which for a door sensor means a missed open/close event.
         """
         if not isinstance(message, dict):
             self._log_unparseable_ws_message(
@@ -207,7 +208,10 @@ class UnifiProtectCoordinator(UnifiBaseCoordinator):
 
         action = message.get("action")
         payload = message.get("payload")
-        containers = [c for c in (payload, action, message) if isinstance(c, dict)]
+        item = message.get("item")
+        containers = [
+            c for c in (payload, action, item, message) if isinstance(c, dict)
+        ]
 
         def _pick(key_camel: str, key_snake: str) -> Any:
             for container in containers:

--- a/custom_components/unifi_insights/coordinators/protect.py
+++ b/custom_components/unifi_insights/coordinators/protect.py
@@ -31,6 +31,8 @@ from custom_components.unifi_insights.const import (
 from .base import UnifiBaseCoordinator
 
 if TYPE_CHECKING:
+    import asyncio
+
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
 
@@ -61,6 +63,7 @@ class UnifiProtectCoordinator(UnifiBaseCoordinator):
         network_client: UniFiNetworkClient,
         protect_client: UniFiProtectClient | None,
         entry: ConfigEntry,
+        site_id: str = "default",
     ) -> None:
         """Initialize the Protect coordinator."""
         super().__init__(
@@ -95,33 +98,93 @@ class UnifiProtectCoordinator(UnifiBaseCoordinator):
             "last_update": None,
         }
 
-        # Register WebSocket callbacks if Protect API is available
-        if self.protect_client:
-            self._setup_websocket_callbacks()
+        # Site ID used for WebSocket subscriptions (ignored for LOCAL REST
+        # calls, kept here for REMOTE/cloud routing - see
+        # ProtectWebSocket._subscribe_path).
+        self._site_id = site_id
 
-    def _setup_websocket_callbacks(self) -> None:
-        """Set up WebSocket callbacks for real-time updates."""
-        if not self.protect_client:
+        # Populated by async_start_websocket(); the background task handle is
+        # read by __init__.py's async_unload_entry to cancel the WebSocket
+        # loop on unload/reload.
+        self.websocket_task: asyncio.Task[None] | None = None
+        self._protect_websocket: Any = (
+            self.protect_client.websocket if self.protect_client else None
+        )
+
+    async def async_start_websocket(self) -> None:
+        """
+        Start the real-time Protect WebSocket subscription.
+
+        This is additive to the 30 second poll (SCAN_INTERVAL_PROTECT), which
+        remains the fallback if the WebSocket is unavailable or drops - it is
+        never removed by this method. Any failure here is logged and
+        swallowed so a WebSocket problem never blocks integration setup or
+        leaves the coordinator without its polling fallback.
+        """
+        if not self.protect_client or not self._protect_websocket:
+            return
+        if self.websocket_task is not None and not self.websocket_task.done():
+            _LOGGER.debug("Protect coordinator: WebSocket already running")
             return
 
         try:
-            registered = False
-            if hasattr(self.protect_client, "register_device_update_callback"):
-                self.protect_client.register_device_update_callback(
-                    self._handle_device_update
-                )
-                registered = True
-            if hasattr(self.protect_client, "register_event_update_callback"):
-                self.protect_client.register_event_update_callback(
-                    self._handle_event_update
-                )
-                registered = True
-            if registered:
-                _LOGGER.debug("Protect coordinator: WebSocket callbacks registered")
+            host_id = await self.protect_client.get_host_id()
         except Exception as err:
-            _LOGGER.debug(
-                "Protect coordinator: WebSocket callbacks not supported: %s", err
+            _LOGGER.warning(
+                "Protect coordinator: Unable to resolve host_id for WebSocket "
+                "subscription, falling back to %s polling only: %s",
+                SCAN_INTERVAL_PROTECT,
+                err,
             )
+            return
+
+        self.websocket_task = self.hass.async_create_background_task(
+            self._protect_websocket.subscribe_with_callback(
+                host_id,
+                self._site_id,
+                "devices",
+                self._on_websocket_message,
+                reconnect=True,
+            ),
+            name=f"{DOMAIN}_protect_websocket",
+        )
+        _LOGGER.debug(
+            "Protect coordinator: WebSocket subscription started (host_id=%s, "
+            "site_id=%s)",
+            host_id,
+            self._site_id,
+        )
+
+    @callback
+    def _on_websocket_message(self, message: dict[str, Any]) -> None:
+        """
+        Adapt a raw WebSocket "devices" message to `_handle_device_update`.
+
+        The message may carry the device fields at the top level or nested
+        under a "payload" key, and the model key may be `modelKey` (API
+        camelCase) or `model_key`. Anything that doesn't parse is logged at
+        warning level rather than dropped silently, since a swallowed frame
+        here is a missed device state change (e.g. a door sensor opening).
+        """
+        if not isinstance(message, dict):
+            _LOGGER.warning(
+                "Protect coordinator: WebSocket message was not a JSON object: %r",
+                message,
+            )
+            return
+
+        payload = message.get("payload")
+        device_data = payload if isinstance(payload, dict) else message
+
+        model_key = device_data.get("modelKey") or device_data.get("model_key")
+        if not model_key:
+            _LOGGER.warning(
+                "Protect coordinator: WebSocket device message missing modelKey: %s",
+                message,
+            )
+            return
+
+        self._handle_device_update(model_key, device_data)
 
     @callback
     def _handle_device_update(
@@ -181,7 +244,12 @@ class UnifiProtectCoordinator(UnifiBaseCoordinator):
                 **device_data,
             }
 
-        self.async_update_listeners()
+        # async_set_updated_data (rather than async_update_listeners) also
+        # marks the last update as successful and resets the poll timer, so
+        # entities relying on last_update_success don't stay unavailable
+        # while WebSocket data is flowing, and the 30s poll fallback re-arms
+        # from the last WebSocket message rather than firing needlessly.
+        self.async_set_updated_data(self.data)
 
     def _normalize_camera_data(self, camera: dict[str, Any]) -> dict[str, Any]:
         """Normalize camera fields across alias and legacy payload shapes."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,9 +166,13 @@ def _create_mock_protect_client() -> MagicMock:
     client.trigger_alarm = AsyncMock(return_value=True)
     client.create_liveview = AsyncMock(return_value={"id": "liveview1"})
     client.update_viewer = AsyncMock(return_value=True)
-    client.register_device_update_callback = MagicMock()
-    client.register_event_update_callback = MagicMock()
-    client.start_websocket = AsyncMock()
+
+    # WebSocket support (real-time device updates, additive to polling)
+    client.get_host_id = AsyncMock(return_value="nvr1")
+    client.websocket = MagicMock()
+    client.websocket.subscribe_with_callback = AsyncMock()
+    client.websocket.stop = MagicMock()
+
     client.close = AsyncMock()
 
     return client

--- a/tests/test_coordinators.py
+++ b/tests/test_coordinators.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 import logging
 from typing import TYPE_CHECKING, Any
@@ -256,9 +257,11 @@ def _create_mock_protect_client() -> MagicMock:
         ]
     )
 
-    # WebSocket registration
-    client.register_device_update_callback = MagicMock()
-    client.register_event_update_callback = MagicMock()
+    # WebSocket support
+    client.get_host_id = AsyncMock(return_value="nvr1")
+    client.websocket = MagicMock()
+    client.websocket.subscribe_with_callback = AsyncMock()
+    client.websocket.stop = MagicMock()
 
     client.close = AsyncMock()
     return client
@@ -1184,27 +1187,122 @@ class TestUnifiProtectCoordinator:
         assert "liveviews" in coordinator.data
         assert "events" in coordinator.data
 
-    def test_websocket_callbacks_registered(self, coordinator: UnifiProtectCoordinator):
-        """Test WebSocket callbacks are registered."""
-        coordinator.protect_client.register_device_update_callback.assert_called_once()
-        coordinator.protect_client.register_event_update_callback.assert_called_once()
+    def test_websocket_state_initialized(self, coordinator: UnifiProtectCoordinator):
+        """Test WebSocket state is initialized but not started at construction."""
+        assert coordinator.websocket_task is None
+        assert coordinator._protect_websocket is coordinator.protect_client.websocket
 
-    def test_websocket_callbacks_not_registered_without_client(
+    def test_websocket_state_without_client(
         self, coordinator_no_protect: UnifiProtectCoordinator
     ):
-        """Test WebSocket callbacks not registered without protect client."""
-        # No assertions needed - just ensure no exceptions
+        """Test WebSocket state without a protect client."""
         assert coordinator_no_protect.protect_client is None
+        assert coordinator_no_protect._protect_websocket is None
+        assert coordinator_no_protect.websocket_task is None
 
-    def test_setup_websocket_callbacks_returns_early_without_client(
+    @pytest.mark.asyncio
+    async def test_async_start_websocket_without_client(
         self, coordinator_no_protect: UnifiProtectCoordinator
     ):
-        """Test _setup_websocket_callbacks returns early without client (line 99)."""
-        # Explicitly call _setup_websocket_callbacks with no protect_client
-        # This should return early and not raise any exceptions
-        coordinator_no_protect._setup_websocket_callbacks()
-        # If we get here, the return statement was executed
-        assert coordinator_no_protect.protect_client is None
+        """Test async_start_websocket returns early without a protect client."""
+        await coordinator_no_protect.async_start_websocket()
+        assert coordinator_no_protect.websocket_task is None
+
+    @pytest.mark.asyncio
+    async def test_async_start_websocket_success(
+        self, hass: HomeAssistant, coordinator: UnifiProtectCoordinator
+    ):
+        """Test async_start_websocket resolves host_id and starts a task."""
+        coordinator.protect_client.get_host_id = AsyncMock(return_value="nvr1")
+        coordinator._protect_websocket.subscribe_with_callback = AsyncMock()
+
+        await coordinator.async_start_websocket()
+
+        assert coordinator.websocket_task is not None
+        coordinator.protect_client.get_host_id.assert_awaited_once()
+        await coordinator.websocket_task
+
+        coordinator._protect_websocket.subscribe_with_callback.assert_awaited_once_with(
+            "nvr1",
+            coordinator._site_id,
+            "devices",
+            coordinator._on_websocket_message,
+            reconnect=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_async_start_websocket_already_running(
+        self, coordinator: UnifiProtectCoordinator
+    ):
+        """Test async_start_websocket is a no-op if already running."""
+        existing_task = asyncio.get_event_loop().create_future()
+        coordinator.websocket_task = existing_task  # type: ignore[assignment]
+        coordinator.protect_client.get_host_id = AsyncMock(return_value="nvr1")
+
+        await coordinator.async_start_websocket()
+
+        coordinator.protect_client.get_host_id.assert_not_called()
+        assert coordinator.websocket_task is existing_task
+        existing_task.set_result(None)
+
+    @pytest.mark.asyncio
+    async def test_async_start_websocket_host_id_failure(
+        self, coordinator: UnifiProtectCoordinator
+    ):
+        """Test async_start_websocket swallows host_id resolution failures."""
+        coordinator.protect_client.get_host_id = AsyncMock(
+            side_effect=Exception("no NVR")
+        )
+
+        # Should not raise - WebSocket is additive, polling stays the fallback.
+        await coordinator.async_start_websocket()
+
+        assert coordinator.websocket_task is None
+
+    def test_on_websocket_message_top_level(self, coordinator: UnifiProtectCoordinator):
+        """Test the WS message adapter with fields at the top level."""
+        coordinator._on_websocket_message(
+            {"modelKey": "sensor", "id": "sensor3", "isOpened": True}
+        )
+
+        assert coordinator.data["sensors"]["sensor3"]["isOpened"] is True
+
+    def test_on_websocket_message_nested_payload(
+        self, coordinator: UnifiProtectCoordinator
+    ):
+        """Test the WS message adapter with fields nested under 'payload'."""
+        coordinator._on_websocket_message(
+            {"payload": {"modelKey": "sensor", "id": "sensor4", "isOpened": False}}
+        )
+
+        assert coordinator.data["sensors"]["sensor4"]["isOpened"] is False
+
+    def test_on_websocket_message_snake_case_model_key(
+        self, coordinator: UnifiProtectCoordinator
+    ):
+        """Test the WS message adapter accepts snake_case model_key."""
+        coordinator._on_websocket_message({"model_key": "light", "id": "light3"})
+
+        assert "light3" in coordinator.data["lights"]
+
+    def test_on_websocket_message_missing_model_key(
+        self, coordinator: UnifiProtectCoordinator, caplog: pytest.LogCaptureFixture
+    ):
+        """Test the WS message adapter warns and drops unparseable messages."""
+        with caplog.at_level(logging.WARNING):
+            coordinator._on_websocket_message({"id": "sensor5"})
+
+        assert "missing modelKey" in caplog.text
+        assert "sensor5" not in coordinator.data["sensors"]
+
+    def test_on_websocket_message_not_a_dict(
+        self, coordinator: UnifiProtectCoordinator, caplog: pytest.LogCaptureFixture
+    ):
+        """Test the WS message adapter warns on non-dict payloads."""
+        with caplog.at_level(logging.WARNING):
+            coordinator._on_websocket_message("not-a-dict")  # type: ignore[arg-type]
+
+        assert "not a JSON object" in caplog.text
 
     @pytest.mark.asyncio
     async def test_async_update_data_success(
@@ -1554,25 +1652,24 @@ class TestUnifiProtectCoordinator:
             # camera2 should be marked for removal
             mock_registry.return_value.async_update_device.assert_called()
 
-    def test_websocket_callbacks_exception(
+    def test_websocket_construction_does_not_start_task(
         self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
     ):
-        """Test WebSocket callback setup handles exceptions gracefully."""
+        """Test constructing the coordinator never starts the WebSocket task.
+
+        Starting requires an await (to resolve host_id), so it must happen via
+        async_start_websocket(), not as a side effect of __init__.
+        """
         network_client = _create_mock_network_client()
         protect_client = _create_mock_protect_client()
-        # Make callback registration raise an exception
-        protect_client.register_device_update_callback = MagicMock(
-            side_effect=Exception("Callback error")
-        )
 
-        # Should not raise - coordinator should handle the exception
         coordinator = UnifiProtectCoordinator(
             hass=hass,
             network_client=network_client,
             protect_client=protect_client,
             entry=mock_config_entry,
         )
-        assert coordinator is not None
+        assert coordinator.websocket_task is None
 
     def test_handle_event_update_unknown_device(
         self, coordinator: UnifiProtectCoordinator
@@ -2693,25 +2790,12 @@ class TestProtectCoordinatorEdgeCases:
             entry=mock_config_entry,
         )
 
-    def test_setup_websocket_callbacks_no_register_device_callback(
+    def test_site_id_default(
         self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
     ):
-        """Test setup when protect_client lacks register_device_update_callback."""
+        """Test the coordinator defaults site_id to 'default' when unset."""
         network_client = _create_mock_network_client()
-        protect_client = MagicMock()
-        # Remove register_device_update_callback from spec
-        del protect_client.register_device_update_callback
-        protect_client.register_event_update_callback = MagicMock()
-        protect_client.cameras = MagicMock()
-        protect_client.cameras.get_all = AsyncMock(return_value=[])
-        protect_client.lights = MagicMock()
-        protect_client.lights.get_all = AsyncMock(return_value=[])
-        protect_client.sensors = MagicMock()
-        protect_client.sensors.get_all = AsyncMock(return_value=[])
-        protect_client.nvr = MagicMock()
-        protect_client.nvr.get = AsyncMock(return_value=MagicMock(id="nvr1"))
-        protect_client.chimes = MagicMock()
-        protect_client.chimes.get_all = AsyncMock(return_value=[])
+        protect_client = _create_mock_protect_client()
 
         coordinator = UnifiProtectCoordinator(
             hass=hass,
@@ -2720,70 +2804,24 @@ class TestProtectCoordinatorEdgeCases:
             entry=mock_config_entry,
         )
 
-        # Should not raise and event callback should still be registered
-        protect_client.register_event_update_callback.assert_called_once()
-        assert coordinator.protect_client is not None
+        assert coordinator._site_id == "default"
 
-    def test_setup_websocket_callbacks_no_register_event_callback(
+    def test_site_id_custom(
         self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
     ):
-        """Test setup when protect_client lacks register_event_update_callback."""
+        """Test the coordinator accepts a custom site_id (REMOTE routing)."""
         network_client = _create_mock_network_client()
-        protect_client = MagicMock()
-        protect_client.register_device_update_callback = MagicMock()
-        # Remove register_event_update_callback from spec
-        del protect_client.register_event_update_callback
-        protect_client.cameras = MagicMock()
-        protect_client.cameras.get_all = AsyncMock(return_value=[])
-        protect_client.lights = MagicMock()
-        protect_client.lights.get_all = AsyncMock(return_value=[])
-        protect_client.sensors = MagicMock()
-        protect_client.sensors.get_all = AsyncMock(return_value=[])
-        protect_client.nvr = MagicMock()
-        protect_client.nvr.get = AsyncMock(return_value=MagicMock(id="nvr1"))
-        protect_client.chimes = MagicMock()
-        protect_client.chimes.get_all = AsyncMock(return_value=[])
+        protect_client = _create_mock_protect_client()
 
         coordinator = UnifiProtectCoordinator(
             hass=hass,
             network_client=network_client,
             protect_client=protect_client,
             entry=mock_config_entry,
+            site_id="site2",
         )
 
-        # Should not raise and device callback should still be registered
-        protect_client.register_device_update_callback.assert_called_once()
-        assert coordinator.protect_client is not None
-
-    def test_setup_websocket_callbacks_exception(
-        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
-    ):
-        """Test setup when callback registration raises exception."""
-        network_client = _create_mock_network_client()
-        protect_client = MagicMock()
-        protect_client.register_device_update_callback = MagicMock(
-            side_effect=Exception("Registration failed")
-        )
-        protect_client.register_event_update_callback = MagicMock()
-        protect_client.cameras = MagicMock()
-        protect_client.cameras.get_all = AsyncMock(return_value=[])
-        protect_client.lights = MagicMock()
-        protect_client.lights.get_all = AsyncMock(return_value=[])
-        protect_client.sensors = MagicMock()
-        protect_client.sensors.get_all = AsyncMock(return_value=[])
-        protect_client.nvr = MagicMock()
-        protect_client.nvr.get = AsyncMock(return_value=MagicMock(id="nvr1"))
-        protect_client.chimes = MagicMock()
-        protect_client.chimes.get_all = AsyncMock(return_value=[])
-
-        # Should not raise
-        coordinator = UnifiProtectCoordinator(
-            hass=hass,
-            network_client=network_client,
-            protect_client=protect_client,
-            entry=mock_config_entry,
-        )
-        assert coordinator.protect_client is not None
+        assert coordinator._site_id == "site2"
 
     @pytest.mark.asyncio
     async def test_fetch_viewers_no_viewers_attribute(

--- a/tests/test_coordinators.py
+++ b/tests/test_coordinators.py
@@ -1277,6 +1277,23 @@ class TestUnifiProtectCoordinator:
 
         assert coordinator.data["sensors"]["sensor4"]["isOpened"] is False
 
+    def test_on_websocket_message_item_wrapper(
+        self, coordinator: UnifiProtectCoordinator
+    ):
+        """Test the WS message adapter with fields nested under 'item'.
+
+        Confirmed live against hardware 2026-08-12: local-console update
+        frames use {"type": "update", "item": {...}}, not top-level fields.
+        """
+        coordinator._on_websocket_message(
+            {
+                "type": "update",
+                "item": {"modelKey": "sensor", "id": "sensor9", "isOpened": True},
+            }
+        )
+
+        assert coordinator.data["sensors"]["sensor9"]["isOpened"] is True
+
     def test_on_websocket_message_snake_case_model_key(
         self, coordinator: UnifiProtectCoordinator
     ):

--- a/tests/test_coordinators.py
+++ b/tests/test_coordinators.py
@@ -1304,6 +1304,89 @@ class TestUnifiProtectCoordinator:
 
         assert "not a JSON object" in caplog.text
 
+    def test_on_websocket_message_action_payload_split(
+        self, coordinator: UnifiProtectCoordinator
+    ):
+        """Test the adapter merges a header/payload-split message.
+
+        Some UniFi WebSocket surfaces split the model identity into an
+        "action" header and the changed fields into "payload" (rather than
+        a single flat object). The adapter must resolve modelKey/id and the
+        field dict independently instead of picking one container and
+        giving up, or a message shaped this way would silently drop every
+        real frame.
+        """
+        coordinator._on_websocket_message(
+            {
+                "action": {"action": "update", "modelKey": "sensor", "id": "sensor6"},
+                "payload": {"isOpened": True},
+            }
+        )
+
+        assert coordinator.data["sensors"]["sensor6"]["id"] == "sensor6"
+        assert coordinator.data["sensors"]["sensor6"]["isOpened"] is True
+
+    def test_on_websocket_message_model_key_without_id(
+        self, coordinator: UnifiProtectCoordinator, caplog: pytest.LogCaptureFixture
+    ):
+        """Test a resolvable modelKey with no id logs at debug, not silently."""
+        with caplog.at_level(logging.DEBUG):
+            coordinator._on_websocket_message({"modelKey": "sensor", "isOpened": True})
+
+        assert "missing device id" in caplog.text
+        assert coordinator.data["sensors"] == {}
+
+    def test_on_websocket_message_warning_capped_after_first(
+        self, coordinator: UnifiProtectCoordinator, caplog: pytest.LogCaptureFixture
+    ):
+        """Test repeated unparseable messages only WARNING once, then DEBUG."""
+        with caplog.at_level(logging.DEBUG):
+            coordinator._on_websocket_message({"id": "sensor7"})
+            caplog.clear()
+            coordinator._on_websocket_message({"id": "sensor8"})
+
+        warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+        debug_records = [r for r in caplog.records if r.levelno == logging.DEBUG]
+        assert warning_records == []
+        assert any("sensor8" in r.getMessage() for r in debug_records)
+
+    @pytest.mark.asyncio
+    async def test_async_stop_websocket_noop_when_never_started(
+        self, coordinator: UnifiProtectCoordinator
+    ):
+        """Test async_stop_websocket is safe when no task was ever started.
+
+        It still calls ProtectWebSocket.stop() unconditionally (harmless -
+        it just sets a flag), but must not touch websocket_task since it's
+        None.
+        """
+        await coordinator.async_stop_websocket()
+
+        assert coordinator.websocket_task is None
+
+    @pytest.mark.asyncio
+    async def test_async_stop_websocket_stops_and_awaits_real_task(
+        self, coordinator: UnifiProtectCoordinator
+    ):
+        """Test async_stop_websocket stops the socket and awaits a real task."""
+        coordinator.protect_client.get_host_id = AsyncMock(return_value="nvr1")
+
+        async def _run_forever(*_args, **_kwargs):
+            await asyncio.sleep(3600)
+
+        coordinator._protect_websocket.subscribe_with_callback = AsyncMock(
+            side_effect=_run_forever
+        )
+        await coordinator.async_start_websocket()
+        task = coordinator.websocket_task
+        assert task is not None
+        assert not task.done()
+
+        await coordinator.async_stop_websocket()
+
+        coordinator._protect_websocket.stop.assert_called_once()
+        assert task.done()
+
     @pytest.mark.asyncio
     async def test_async_update_data_success(
         self, coordinator: UnifiProtectCoordinator

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -151,6 +151,54 @@ async def test_unload_entry(
     assert init_integration.state == ConfigEntryState.NOT_LOADED
 
 
+async def test_setup_entry_starts_protect_websocket(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    enable_custom_integrations,
+) -> None:
+    """Test setup resolves host_id and starts the real-time WebSocket.
+
+    Regression test for the dead `hasattr(..., "register_device_update_callback")`
+    stub: the coordinator must actually invoke `get_host_id()` and hand a real
+    background task to `ProtectWebSocket.subscribe_with_callback`, not just
+    construct without error.
+    """
+    runtime_data = init_integration.runtime_data
+    protect_coordinator = runtime_data.protect_coordinator
+    assert protect_coordinator is not None
+
+    runtime_data.protect_client.get_host_id.assert_awaited_once()
+    assert protect_coordinator.websocket_task is not None
+    await protect_coordinator.websocket_task
+    protect_coordinator._protect_websocket.subscribe_with_callback.assert_awaited_once()
+
+
+async def test_unload_entry_cancels_real_websocket_task(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    enable_custom_integrations,
+) -> None:
+    """Test unload stops the ProtectWebSocket and cancels/awaits the real task.
+
+    Regression test: `websocket_task.cancel()` alone does not stop
+    `subscribe_with_callback`'s reconnect loop (it swallowed
+    `CancelledError` and slept/reconnected instead), which would leave an
+    orphaned WebSocket loop running after a config entry reload.
+    """
+    runtime_data = init_integration.runtime_data
+    protect_coordinator = runtime_data.protect_coordinator
+    assert protect_coordinator is not None
+    websocket_task = protect_coordinator.websocket_task
+    assert websocket_task is not None
+
+    assert await hass.config_entries.async_unload(init_integration.entry_id)
+    await hass.async_block_till_done()
+
+    assert init_integration.state == ConfigEntryState.NOT_LOADED
+    protect_coordinator._protect_websocket.stop.assert_called_once()
+    assert websocket_task.done()
+
+
 async def test_reload_entry(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -195,7 +195,13 @@ async def test_unload_entry_cancels_real_websocket_task(
     await hass.async_block_till_done()
 
     assert init_integration.state == ConfigEntryState.NOT_LOADED
-    protect_coordinator._protect_websocket.stop.assert_called_once()
+    # Called twice by design: once from async_unload_entry's explicit call
+    # (correct ordering - stop before closing the Protect client) and once
+    # more via the entry.async_on_unload safety net registered in
+    # async_setup_entry (covers a setup failure that happens after the
+    # WebSocket starts but before async_unload_entry ever runs).
+    # async_stop_websocket() is idempotent, so this is expected, not a bug.
+    assert protect_coordinator._protect_websocket.stop.call_count == 2
     assert websocket_task.done()
 
 

--- a/tests/test_protect_websocket.py
+++ b/tests/test_protect_websocket.py
@@ -1,0 +1,210 @@
+"""Tests for the vendored UniFi Protect WebSocket client.
+
+This module lives under `custom_components/unifi_insights/api/**`, which is
+excluded from the coverage gate (see `[tool.coverage.run].omit` in
+pyproject.toml) because it is a vendored package. It still runs live against
+production door-lock sensors, so it is tested directly here regardless of the
+gate.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import aiohttp
+import pytest
+
+from custom_components.unifi_insights.api import ApiKeyAuth, ConnectionType, LocalAuth
+from custom_components.unifi_insights.api.protect import UniFiProtectClient
+from custom_components.unifi_insights.api.protect.websocket import ProtectWebSocket
+
+
+def _local_client() -> UniFiProtectClient:
+    return UniFiProtectClient(
+        auth=LocalAuth(api_key="test-key", verify_ssl=False),
+        base_url="https://192.168.1.1",
+        connection_type=ConnectionType.LOCAL,
+    )
+
+
+def _remote_client() -> UniFiProtectClient:
+    return UniFiProtectClient(
+        auth=ApiKeyAuth(api_key="test-key"),
+        connection_type=ConnectionType.REMOTE,
+        console_id="console-1",
+    )
+
+
+def test_subscribe_path_local_uses_integration_api() -> None:
+    """LOCAL WS subscribe path must match the client's own REST convention.
+
+    Regression test: the WS path used to be hardcoded to a cloud-only
+    `/ea/hosts/{host_id}/sites/{site_id}/subscribe/...` scheme that does not
+    exist on a local console, which made the WebSocket silently non-functional
+    for LOCAL (including Protect-only) consoles.
+    """
+    client = _local_client()
+
+    assert (
+        client.websocket._subscribe_path("devices")
+        == "/proxy/protect/integration/v1/subscribe/devices"
+    )
+    assert (
+        client.websocket._subscribe_path("events")
+        == "/proxy/protect/integration/v1/subscribe/events"
+    )
+
+
+def test_subscribe_path_remote_uses_connector_routing() -> None:
+    """REMOTE WS subscribe path must route through the connector like REST calls."""
+    client = _remote_client()
+
+    assert client.websocket._subscribe_path("devices") == (
+        "/v1/connector/consoles/console-1/protect/integration/v1/subscribe/devices"
+    )
+
+
+def _make_ws(messages: list[aiohttp.WSMessage]) -> MagicMock:
+    """Build a fake aiohttp WebSocket that yields the given messages then ends."""
+    ws = MagicMock()
+    ws.closed = False
+
+    async def _aiter():
+        for msg in messages:
+            yield msg
+
+    ws.__aiter__ = lambda self=ws: _aiter()
+    ws.close = AsyncMock(side_effect=lambda: setattr(ws, "closed", True))
+    return ws
+
+
+@pytest.mark.asyncio
+async def test_subscribe_with_callback_dispatches_messages() -> None:
+    """A single successful connection delivers decoded JSON messages."""
+    client = _local_client()
+    ws_socket = ProtectWebSocket(client)
+
+    text_msg = MagicMock(type=aiohttp.WSMsgType.TEXT, data='{"modelKey": "sensor"}')
+    close_msg = MagicMock(type=aiohttp.WSMsgType.CLOSED)
+    fake_ws = _make_ws([text_msg, close_msg])
+
+    ws_socket._connect = AsyncMock(return_value=fake_ws)
+    received: list[dict] = []
+
+    await ws_socket.subscribe_with_callback(
+        "nvr1", "default", "devices", received.append, reconnect=False
+    )
+
+    assert received == [{"modelKey": "sensor"}]
+    fake_ws.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_subscribe_with_callback_invalid_subscription_type() -> None:
+    """Only 'devices'/'events' are valid subscription types."""
+    client = _local_client()
+    ws_socket = ProtectWebSocket(client)
+
+    with pytest.raises(ValueError, match=r"devices.*events"):
+        await ws_socket.subscribe_with_callback(
+            "nvr1", "default", "bogus", lambda _msg: None
+        )
+
+
+@pytest.mark.asyncio
+async def test_subscribe_with_callback_drops_invalid_json(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Non-JSON text frames are dropped without invoking the callback."""
+    client = _local_client()
+    ws_socket = ProtectWebSocket(client)
+
+    bad_msg = MagicMock(type=aiohttp.WSMsgType.TEXT, data="not-json")
+    close_msg = MagicMock(type=aiohttp.WSMsgType.CLOSED)
+    fake_ws = _make_ws([bad_msg, close_msg])
+    ws_socket._connect = AsyncMock(return_value=fake_ws)
+
+    callback = MagicMock()
+    with caplog.at_level(logging.DEBUG):
+        await ws_socket.subscribe_with_callback(
+            "nvr1", "default", "devices", callback, reconnect=False
+        )
+
+    callback.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_subscribe_with_callback_reconnects_after_client_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A connection error is logged at WARNING and triggers a reconnect."""
+    client = _local_client()
+    ws_socket = ProtectWebSocket(client)
+
+    close_msg = MagicMock(type=aiohttp.WSMsgType.CLOSED)
+    good_ws = _make_ws([close_msg])
+
+    connect_calls = 0
+
+    async def _connect(_path: str):
+        nonlocal connect_calls
+        connect_calls += 1
+        if connect_calls == 1:
+            msg = "handshake failed"
+            raise aiohttp.ClientConnectionError(msg)
+        # Second attempt succeeds, then subscribe_with_callback stops because
+        # reconnect=False keeps _running True only for one more loop; force
+        # stop from within the second connection.
+        ws_socket.stop()
+        return good_ws
+
+    ws_socket._connect = _connect
+
+    with caplog.at_level(logging.WARNING):
+        await ws_socket.subscribe_with_callback(
+            "nvr1",
+            "default",
+            "devices",
+            lambda _msg: None,
+            reconnect=True,
+            reconnect_delay=0,
+        )
+
+    assert connect_calls == 2
+    assert "connection error" in caplog.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_subscribe_with_callback_propagates_cancellation() -> None:
+    """Cancellation must propagate, not be swallowed into a reconnect loop.
+
+    Regression test: the previous implementation caught
+    `asyncio.CancelledError` alongside `aiohttp.ClientError` and fell through
+    to the reconnect-sleep branch, so `task.cancel()` from the integration's
+    unload path never actually stopped the background WebSocket loop.
+    """
+    client = _local_client()
+    ws_socket = ProtectWebSocket(client)
+
+    async def _connect(_path: str):
+        raise asyncio.CancelledError
+
+    ws_socket._connect = _connect
+
+    with pytest.raises(asyncio.CancelledError):
+        await ws_socket.subscribe_with_callback(
+            "nvr1", "default", "devices", lambda _msg: None
+        )
+
+
+def test_stop_sets_running_false() -> None:
+    """stop() flips the running flag so the reconnect loop exits."""
+    client = _local_client()
+    ws_socket = ProtectWebSocket(client)
+    ws_socket._running = True
+
+    ws_socket.stop()
+
+    assert ws_socket._running is False


### PR DESCRIPTION
Protect entities only update on the 30s poll. A door that opens and closes inside that window never reaches Home Assistant.

The cause is a dead code path. `UnifiProtectCoordinator._setup_websocket_callbacks` gates registration on `hasattr(protect_client, "register_device_update_callback")`, and that method does not exist anywhere in the client, so the check always fails and the function silently does nothing.

Underneath it, two more things were wrong:

- Nothing ever instantiated or drove `ProtectWebSocket` (`api/protect/websocket.py`). The class was written but unused.
- `ProtectWebSocket._connect()` hardcoded `/ea/hosts/{host_id}/sites/{site_id}/subscribe/...`, a cloud-only path from a different UniFi API surface, instead of going through `build_api_path()` like every other endpoint. On a local console that path does not exist, so even a correct call into it would have reconnect-looped forever without logging anything above debug.

### What changed

`api/protect/websocket.py` builds subscribe paths through `build_api_path()` for both LOCAL and REMOTE, logs the connection URL and errors at WARNING instead of looping silently every 5s, and lets `CancelledError` propagate rather than routing it into the reconnect branch, which is why `task.cancel()` on unload never actually stopped the loop.

`coordinators/protect.py` drops the dead hasattr stub and adds `async_start_websocket()`, which resolves `host_id` via `get_host_id()` and starts a background task on the "devices" stream, storing it as `websocket_task` — the attribute the unload path in `__init__.py` already expected but which nothing populated. host_id failures are swallowed on purpose: the WebSocket is additive and must not block setup or remove the poll fallback. Handlers call `async_set_updated_data()` rather than `async_update_listeners()`, so `last_update_success` reflects live data and the poll timer re-arms from the last WS message.

`__init__.py` starts the socket after first refresh, resolves `site_id` (`"default"` for LOCAL, first Network site for REMOTE), and on unload stops the socket before cancelling and awaiting the task, so a reload cannot orphan a running loop.

### Wire format

This took a round trip against real hardware. My first version read `modelKey` and `id` from the top level or from `payload`. A local console actually sends `{"type": "update", "item": {id, modelKey, ...}}`, and every frame was being dropped with "missing modelKey". The parser now resolves `modelKey`, `id` and the field dict independently across `item`, `payload`, `action` and the top level, so all the shapes go through one code path. Unparseable frames log one WARNING and then drop to DEBUG rather than storming the log.

### Leak on failed setup

If `async_forward_entry_setups` raises after the socket task has started, `async_unload_entry` is never called for that entry and the socket reconnects forever with no owner. The stop sequence is now an idempotent `async_stop_websocket()`, registered via `entry.async_on_unload()` immediately after the task starts, which HA runs even when setup fails. The normal unload path calls the same method directly.

### Tests

`tests/test_protect_websocket.py` is new; `ProtectWebSocket` had no coverage at all. The coordinator tests that asserted the dead stub are rewritten, and `test_init.py` gains integration tests that drive the real `asyncio.Task` through setup and unload.

Running in production on a UNVR-PRO. Scope here is the "devices" subscription; `_handle_event_update` stays unwired and is the subject of a follow-up.
