### PR TITLE
fix(protect): subscribe to the events stream so camera motion sensors work

### DIFF
--- a/custom_components/unifi_insights/__init__.py
+++ b/custom_components/unifi_insights/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from dataclasses import dataclass
 import logging
 from typing import TYPE_CHECKING, TypeAlias
@@ -310,6 +311,14 @@ async def async_setup_entry(
     )
 
     # 3. Protect coordinator - fast updates (30 seconds) + WebSocket for events
+    # WebSocket site_id: LOCAL consoles ignore site_id for the Protect REST/WS
+    # paths, so "default" is fine. REMOTE (cloud connector) routing uses the
+    # console_id embedded in the path, but if the Network API returned sites
+    # for this console, prefer the first real site id over the placeholder.
+    protect_site_id = "default"
+    if not is_local and network_available and sites:
+        protect_site_id = sites[0].id
+
     protect_coordinator: UnifiProtectCoordinator | None = None
     if protect_client:
         protect_coordinator = UnifiProtectCoordinator(
@@ -317,6 +326,7 @@ async def async_setup_entry(
             network_client=network_client,
             protect_client=protect_client,
             entry=entry,
+            site_id=protect_site_id,
         )
 
     # Fetch initial data - config first, then device/protect in parallel
@@ -328,6 +338,12 @@ async def async_setup_entry(
     if protect_coordinator:
         refresh_tasks.append(protect_coordinator.async_config_entry_first_refresh())
     await asyncio.gather(*refresh_tasks)
+
+    # Start the real-time Protect WebSocket subscription (additive to the
+    # 30s poll above, which stays as the fallback - see
+    # UnifiProtectCoordinator.async_start_websocket).
+    if protect_coordinator:
+        await protect_coordinator.async_start_websocket()
 
     # Create facade coordinator for backward compatibility with entity classes
     # (it aggregates the initial data from the sub-coordinators on creation)
@@ -378,13 +394,27 @@ async def async_unload_entry(
         data = entry.runtime_data
         _LOGGER.debug("Closing API clients")
         if data.protect_client:
-            # Stop WebSocket if active (on protect coordinator)
+            # Stop WebSocket if active (on protect coordinator). Signal the
+            # ProtectWebSocket loop to stop reconnecting *before* cancelling
+            # the task, then await the cancellation - cancel() alone leaves
+            # the reconnect loop free to spin back up, and the loop being
+            # parked in `async for msg in ws` means stop() alone won't
+            # unblock it either; both are needed to avoid an orphaned
+            # WebSocket loop surviving a config entry reload.
             if data.protect_coordinator:
+                protect_websocket = getattr(
+                    data.protect_coordinator, "_protect_websocket", None
+                )
+                if protect_websocket:
+                    protect_websocket.stop()
                 websocket_task = getattr(
                     data.protect_coordinator, "websocket_task", None
                 )
                 if websocket_task:
                     websocket_task.cancel()
+                    if isinstance(websocket_task, asyncio.Task):
+                        with contextlib.suppress(asyncio.CancelledError, Exception):
+                            await websocket_task
             # Close Protect client (await the async close)
             try:
                 await data.protect_client.close()

--- a/custom_components/unifi_insights/__init__.py
+++ b/custom_components/unifi_insights/__init__.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 from dataclasses import dataclass
 import logging
 from typing import TYPE_CHECKING, TypeAlias
@@ -341,9 +340,13 @@ async def async_setup_entry(
 
     # Start the real-time Protect WebSocket subscription (additive to the
     # 30s poll above, which stays as the fallback - see
-    # UnifiProtectCoordinator.async_start_websocket).
+    # UnifiProtectCoordinator.async_start_websocket). Registered for
+    # on-unload cleanup immediately so a setup failure later in this
+    # function (e.g. platform forwarding below) can't leak the background
+    # task - HA still runs async_on_unload callbacks when setup fails.
     if protect_coordinator:
         await protect_coordinator.async_start_websocket()
+        entry.async_on_unload(protect_coordinator.async_stop_websocket)
 
     # Create facade coordinator for backward compatibility with entity classes
     # (it aggregates the initial data from the sub-coordinators on creation)
@@ -394,27 +397,17 @@ async def async_unload_entry(
         data = entry.runtime_data
         _LOGGER.debug("Closing API clients")
         if data.protect_client:
-            # Stop WebSocket if active (on protect coordinator). Signal the
-            # ProtectWebSocket loop to stop reconnecting *before* cancelling
-            # the task, then await the cancellation - cancel() alone leaves
-            # the reconnect loop free to spin back up, and the loop being
-            # parked in `async for msg in ws` means stop() alone won't
-            # unblock it either; both are needed to avoid an orphaned
-            # WebSocket loop surviving a config entry reload.
+            # Stop the WebSocket (and await its background task) *before*
+            # closing the client below - stopping it after would leave the
+            # loop trying to use an already-closed session for whatever
+            # brief window passes before entry.async_on_unload's registered
+            # copy of this same call runs (see async_setup_entry - that
+            # registration is the safety net for a setup failure that
+            # happens after the WebSocket starts but before this function
+            # ever runs; async_stop_websocket() is idempotent so running it
+            # twice on a normal unload is harmless).
             if data.protect_coordinator:
-                protect_websocket = getattr(
-                    data.protect_coordinator, "_protect_websocket", None
-                )
-                if protect_websocket:
-                    protect_websocket.stop()
-                websocket_task = getattr(
-                    data.protect_coordinator, "websocket_task", None
-                )
-                if websocket_task:
-                    websocket_task.cancel()
-                    if isinstance(websocket_task, asyncio.Task):
-                        with contextlib.suppress(asyncio.CancelledError, Exception):
-                            await websocket_task
+                await data.protect_coordinator.async_stop_websocket()
             # Close Protect client (await the async close)
             try:
                 await data.protect_client.close()

--- a/custom_components/unifi_insights/api/protect/websocket.py
+++ b/custom_components/unifi_insights/api/protect/websocket.py
@@ -85,7 +85,15 @@ class ProtectWebSocket:
         url = str(self._client._build_url(path)).replace("https://", "wss://")
         headers = self._client._get_headers()
 
-        ws = await session.ws_connect(url, headers=headers)
+        # heartbeat=30: without this, a half-open connection - the NVR
+        # stops responding but never sends a close/error frame - leaves
+        # `async for msg in ws` in subscribe_with_callback blocked forever,
+        # so the reconnect loop never gets a chance to run (review finding
+        # 1). aiohttp sends a ping every 30s and force-closes the
+        # connection (surfacing as WSMsgType.CLOSED/ERROR, which
+        # subscribe_with_callback already handles) if no pong comes back,
+        # turning a silent hang into a bounded-time reconnect instead.
+        ws = await session.ws_connect(url, headers=headers, heartbeat=30)
         return ws
 
     @asynccontextmanager

--- a/custom_components/unifi_insights/api/protect/websocket.py
+++ b/custom_components/unifi_insights/api/protect/websocket.py
@@ -195,6 +195,7 @@ class ProtectWebSocket:
         *,
         reconnect: bool = True,
         reconnect_delay: float = 5.0,
+        on_connection_state_change: Callable[[bool], None] | None = None,
     ) -> None:
         """
         Subscribe with a callback function.
@@ -206,6 +207,17 @@ class ProtectWebSocket:
             callback: Function to call for each message.
             reconnect: Whether to automatically reconnect on disconnect.
             reconnect_delay: Delay in seconds before reconnecting.
+            on_connection_state_change: Optional callback invoked with `True`
+                immediately after a connection is established and `False`
+                whenever it ends (clean close, error, or before a retry).
+                This is the only place that knows about connect/reconnect
+                transitions, so callers that need to reconcile state around
+                a reconnect (or surface WS health) must observe it here
+                rather than trying to infer it from `callback` traffic
+                alone. Exceptions raised by this callback are logged and
+                swallowed - a bug in it must never take down the reconnect
+                loop, the exact "silent background task death" failure mode
+                this parameter otherwise helps observe.
 
         """
         if subscription_type not in ("devices", "events"):
@@ -213,6 +225,18 @@ class ProtectWebSocket:
 
         path = self._subscribe_path(subscription_type)
         self._running = True
+
+        def _report_state(*, connected: bool) -> None:
+            if on_connection_state_change is None:
+                return
+            try:
+                on_connection_state_change(connected)
+            except Exception:
+                _LOGGER.exception(
+                    "ProtectWebSocket: on_connection_state_change callback raised "
+                    "for %s subscription",
+                    subscription_type,
+                )
 
         while self._running:
             ws: aiohttp.ClientWebSocketResponse | None = None
@@ -225,6 +249,7 @@ class ProtectWebSocket:
                     host_id,
                     site_id,
                 )
+                _report_state(connected=True)
 
                 async for msg in ws:
                     if not self._running:
@@ -234,9 +259,7 @@ class ProtectWebSocket:
                             data = json.loads(msg.data)
                             callback(data)
                         except json.JSONDecodeError:
-                            _LOGGER.debug(
-                                "ProtectWebSocket: dropped non-JSON message"
-                            )
+                            _LOGGER.debug("ProtectWebSocket: dropped non-JSON message")
                             continue
                     elif msg.type in (
                         aiohttp.WSMsgType.ERROR,
@@ -258,6 +281,7 @@ class ProtectWebSocket:
                     err,
                 )
             finally:
+                _report_state(connected=False)
                 if ws is not None and not ws.closed:
                     await ws.close()
 

--- a/custom_components/unifi_insights/api/protect/websocket.py
+++ b/custom_components/unifi_insights/api/protect/websocket.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any
@@ -12,6 +13,8 @@ import aiohttp
 
 if TYPE_CHECKING:
     from .client import UniFiProtectClient
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class ProtectWebSocket:
@@ -23,6 +26,13 @@ class ProtectWebSocket:
     To use WebSocket subscriptions, you need a `host_id` and `site_id`:
     - `host_id`: The NVR ID, obtainable via `await client.get_host_id()`
     - `site_id`: For local connections, use "default". For remote, get from cloud API.
+
+    `host_id`/`site_id` are accepted for API compatibility and potential future
+    multi-site routing, but the subscribe path is currently built the same way
+    as every other Protect endpoint - via `client.build_api_path()` - so that it
+    honours LOCAL (`/proxy/protect/integration/v1/subscribe/...`) vs REMOTE
+    (`/v1/connector/consoles/{console_id}/protect/integration/v1/subscribe/...`)
+    routing consistently with the REST endpoints on this client.
 
     Example:
         ```python
@@ -50,9 +60,17 @@ class ProtectWebSocket:
         self._ws: aiohttp.ClientWebSocketResponse | None = None
         self._running = False
 
-    async def _connect(
-        self, path: str
-    ) -> aiohttp.ClientWebSocketResponse:  # pragma: no cover
+    def _subscribe_path(self, subscription_type: str) -> str:
+        """
+        Build the subscribe path for the given subscription type.
+
+        Uses the same `build_api_path()` convention as every other Protect
+        endpoint on this client, so LOCAL and REMOTE connections are routed
+        correctly (see class docstring).
+        """
+        return self._client.build_api_path(f"/subscribe/{subscription_type}")
+
+    async def _connect(self, path: str) -> aiohttp.ClientWebSocketResponse:
         """
         Establish WebSocket connection.
 
@@ -92,7 +110,7 @@ class ProtectWebSocket:
                     print(f"Device update: {update}")
 
         """
-        path = f"/ea/hosts/{host_id}/sites/{site_id}/subscribe/devices"
+        path = self._subscribe_path("devices")
         ws = await self._connect(path)
         self._running = True
 
@@ -141,7 +159,7 @@ class ProtectWebSocket:
                     print(f"Event: {event}")
 
         """
-        path = f"/ea/hosts/{host_id}/sites/{site_id}/subscribe/events"
+        path = self._subscribe_path("events")
         ws = await self._connect(path)
         self._running = True
 
@@ -193,14 +211,20 @@ class ProtectWebSocket:
         if subscription_type not in ("devices", "events"):
             raise ValueError("subscription_type must be 'devices' or 'events'")
 
-        self._running = True  # pragma: no cover
+        path = self._subscribe_path(subscription_type)
+        self._running = True
 
-        while self._running:  # pragma: no cover
+        while self._running:
+            ws: aiohttp.ClientWebSocketResponse | None = None
             try:
-                path = (
-                    f"/ea/hosts/{host_id}/sites/{site_id}/subscribe/{subscription_type}"
-                )
                 ws = await self._connect(path)
+                _LOGGER.debug(
+                    "ProtectWebSocket: connected for %s subscription (host_id=%s, "
+                    "site_id=%s)",
+                    subscription_type,
+                    host_id,
+                    site_id,
+                )
 
                 async for msg in ws:
                     if not self._running:
@@ -210,18 +234,32 @@ class ProtectWebSocket:
                             data = json.loads(msg.data)
                             callback(data)
                         except json.JSONDecodeError:
+                            _LOGGER.debug(
+                                "ProtectWebSocket: dropped non-JSON message"
+                            )
                             continue
                     elif msg.type in (
                         aiohttp.WSMsgType.ERROR,
                         aiohttp.WSMsgType.CLOSED,
                     ):
                         break
-
-                await ws.close()
-
-            except (aiohttp.ClientError, asyncio.CancelledError):
-                # Expected during disconnects or cancellations; allow reconnection logic below
-                pass
+            except asyncio.CancelledError:
+                # Cancellation must propagate so the owning task actually
+                # stops instead of silently looping into a reconnect below.
+                raise
+            except aiohttp.ClientError as err:
+                # Expected during disconnects; log so a hardware/URL problem
+                # is visible instead of a silent reconnect loop, then allow
+                # the reconnection logic below to run.
+                _LOGGER.warning(
+                    "ProtectWebSocket: connection error subscribing to %s at %s: %s",
+                    subscription_type,
+                    path,
+                    err,
+                )
+            finally:
+                if ws is not None and not ws.closed:
+                    await ws.close()
 
             if self._running and reconnect:
                 await asyncio.sleep(reconnect_delay)

--- a/custom_components/unifi_insights/coordinators/protect.py
+++ b/custom_components/unifi_insights/coordinators/protect.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 from datetime import UTC, datetime
 import logging
 from typing import TYPE_CHECKING, Any
@@ -31,8 +33,6 @@ from custom_components.unifi_insights.const import (
 from .base import UnifiBaseCoordinator
 
 if TYPE_CHECKING:
-    import asyncio
-
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
 
@@ -110,6 +110,10 @@ class UnifiProtectCoordinator(UnifiBaseCoordinator):
         self._protect_websocket: Any = (
             self.protect_client.websocket if self.protect_client else None
         )
+        # Caps the "can't parse WebSocket message" warning to once, so a
+        # persistently wrong frame shape can't log-storm a production
+        # instance; every subsequent occurrence still logs at debug.
+        self._ws_parse_warned = False
 
     async def async_start_websocket(self) -> None:
         """
@@ -155,36 +159,94 @@ class UnifiProtectCoordinator(UnifiBaseCoordinator):
             self._site_id,
         )
 
+    async def async_stop_websocket(self) -> None:
+        """
+        Stop the WebSocket subscription and await its background task.
+
+        Safe to call when the WebSocket was never started. Signals the
+        `ProtectWebSocket` loop to stop reconnecting *before* cancelling the
+        task, then awaits the cancellation - `cancel()` alone leaves the
+        reconnect loop free to spin back up, and the loop being parked in
+        `async for msg in ws` means `stop()` alone won't unblock it either;
+        both are needed to avoid an orphaned WebSocket loop.
+
+        Registered with `entry.async_on_unload()` (covers a setup failure
+        that happens after the WebSocket started but before setup
+        completes) and also called directly from `async_unload_entry`'s
+        normal unload path.
+        """
+        if self._protect_websocket:
+            self._protect_websocket.stop()
+        task = self.websocket_task
+        if task:
+            task.cancel()
+            if isinstance(task, asyncio.Task):
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await task
+
     @callback
     def _on_websocket_message(self, message: dict[str, Any]) -> None:
         """
         Adapt a raw WebSocket "devices" message to `_handle_device_update`.
 
-        The message may carry the device fields at the top level or nested
-        under a "payload" key, and the model key may be `modelKey` (API
-        camelCase) or `model_key`. Anything that doesn't parse is logged at
-        warning level rather than dropped silently, since a swallowed frame
-        here is a missed device state change (e.g. a door sensor opening).
+        The exact wire shape for this API is not verified against hardware
+        (see AGENTS.md / commit message), so `modelKey` and `id` are each
+        resolved independently across every plausible container - top level,
+        a "payload" key (REST-response-shaped push), and an "action" key
+        (the header/payload split used by UniFi's private app WebSocket) -
+        rather than picking one container and giving up. Picking a single
+        container wrong would silently drop every real frame, which for a
+        door sensor means a missed open/close event.
         """
         if not isinstance(message, dict):
-            _LOGGER.warning(
+            self._log_unparseable_ws_message(
                 "Protect coordinator: WebSocket message was not a JSON object: %r",
                 message,
             )
             return
 
+        action = message.get("action")
         payload = message.get("payload")
-        device_data = payload if isinstance(payload, dict) else message
+        containers = [c for c in (payload, action, message) if isinstance(c, dict)]
 
-        model_key = device_data.get("modelKey") or device_data.get("model_key")
+        def _pick(key_camel: str, key_snake: str) -> Any:
+            for container in containers:
+                value = container.get(key_camel) or container.get(key_snake)
+                if value:
+                    return value
+            return None
+
+        model_key = _pick("modelKey", "model_key")
         if not model_key:
-            _LOGGER.warning(
+            self._log_unparseable_ws_message(
                 "Protect coordinator: WebSocket device message missing modelKey: %s",
                 message,
             )
             return
 
+        device_id = _pick("id", "id")
+        if not device_id:
+            _LOGGER.debug(
+                "Protect coordinator: WebSocket %s update missing device id: %s",
+                model_key,
+                message,
+            )
+            return
+
+        # Merge every dict container so fields split across payload/action
+        # (e.g. id in the header, state fields in the payload) are all kept.
+        device_data: dict[str, Any] = {}
+        for container in reversed(containers):
+            device_data.update(container)
+        device_data["id"] = device_id
+
         self._handle_device_update(model_key, device_data)
+
+    def _log_unparseable_ws_message(self, msg: str, *args: Any) -> None:
+        """Log an unparseable WS message once at WARNING, then at DEBUG."""
+        level = logging.WARNING if not self._ws_parse_warned else logging.DEBUG
+        _LOGGER.log(level, msg, *args)
+        self._ws_parse_warned = True
 
     @callback
     def _handle_device_update(

--- a/custom_components/unifi_insights/coordinators/protect.py
+++ b/custom_components/unifi_insights/coordinators/protect.py
@@ -189,14 +189,15 @@ class UnifiProtectCoordinator(UnifiBaseCoordinator):
         """
         Adapt a raw WebSocket "devices" message to `_handle_device_update`.
 
-        The exact wire shape for this API is not verified against hardware
-        (see AGENTS.md / commit message), so `modelKey` and `id` are each
-        resolved independently across every plausible container - top level,
-        a "payload" key (REST-response-shaped push), and an "action" key
-        (the header/payload split used by UniFi's private app WebSocket) -
-        rather than picking one container and giving up. Picking a single
-        container wrong would silently drop every real frame, which for a
-        door sensor means a missed open/close event.
+        Confirmed live against hardware 2026-08-12: the local-console shape is
+        `{"type": "update", "item": {"id", "modelKey", ...fields}}` - the
+        device delta lives under an "item" key, not at top level. `modelKey`
+        and `id` are still resolved independently across every plausible
+        container - "item", a "payload" key (REST-response-shaped push), and
+        an "action" key (the header/payload split used by UniFi's private
+        app WebSocket) - rather than picking one container and giving up.
+        Picking a single container wrong would silently drop every real
+        frame, which for a door sensor means a missed open/close event.
         """
         if not isinstance(message, dict):
             self._log_unparseable_ws_message(
@@ -207,7 +208,10 @@ class UnifiProtectCoordinator(UnifiBaseCoordinator):
 
         action = message.get("action")
         payload = message.get("payload")
-        containers = [c for c in (payload, action, message) if isinstance(c, dict)]
+        item = message.get("item")
+        containers = [
+            c for c in (payload, action, item, message) if isinstance(c, dict)
+        ]
 
         def _pick(key_camel: str, key_snake: str) -> Any:
             for container in containers:

--- a/custom_components/unifi_insights/coordinators/protect.py
+++ b/custom_components/unifi_insights/coordinators/protect.py
@@ -177,15 +177,33 @@ class UnifiProtectCoordinator(UnifiBaseCoordinator):
         self._ws_parse_warned = False
         self._ws_event_parse_warned = False
 
-        # WebSocket health signal (task 5): there was previously no way to
-        # tell "connected and delivering" from "connected but silent" from
-        # "reconnect-looping" - surfaced via `websocket_health` in
-        # diagnostics.py. `_last_ws_message` updates on ANY inbound frame
-        # (devices or events, even an unparseable one - receiving anything
-        # is evidence the wire is alive); `_ws_connected` mirrors the
-        # underlying ProtectWebSocket connect/disconnect transitions
-        # (combined across both subscriptions - see
-        # `_on_websocket_connection_state_change`).
+        # WebSocket health signal (task 5, hardened by review finding 1):
+        # there was previously no way to tell "connected and delivering"
+        # from "connected but silent" from "reconnect-looping" - surfaced
+        # via `websocket_health` in diagnostics.py.
+        #
+        # Tracked PER SUBSCRIPTION, not as one shared pair of fields: the
+        # devices and events subscriptions are independent WebSocket
+        # connections (see async_start_websocket), and a shared field would
+        # let a chatty devices stream mask a hung/disconnected events
+        # stream - exactly the "motion silently stopped working for days"
+        # failure this signal exists to catch (an NVR restart where devices
+        # reconnects cleanly but events hangs half-open forever, no error,
+        # no close frame). See `_mark_ws_frame_received` and
+        # `_on_websocket_connection_state_change`.
+        self._ws_stream_health: dict[str, dict[str, Any]] = {
+            "devices": {"connected": False, "last_message_at": None},
+            "events": {"connected": False, "last_message_at": None},
+        }
+        # Top-level roll-up, recomputed by `_recompute_ws_health_rollup()`
+        # on every per-stream update. `connected` is True only when BOTH
+        # streams are connected (so a half-dead pair correctly reads as
+        # unhealthy even without inspecting the per-stream detail);
+        # `last_message_at` is the most recent frame from EITHER stream
+        # (preserves the old "any wire alive" semantics as a coarse
+        # liveness signal). Kept as real fields (not just derived in the
+        # `websocket_health` property) so backwards-compatible attribute
+        # access (`coordinator._ws_connected`) keeps working.
         self._last_ws_message: datetime | None = None
         self._ws_connected: bool = False
 
@@ -234,7 +252,7 @@ class UnifiProtectCoordinator(UnifiBaseCoordinator):
                 "devices",
                 self._on_websocket_message,
                 reconnect=True,
-                on_connection_state_change=self._on_websocket_connection_state_change,
+                on_connection_state_change=self._on_devices_connection_state_change,
             ),
             name=f"{DOMAIN}_protect_websocket",
         )
@@ -253,7 +271,7 @@ class UnifiProtectCoordinator(UnifiBaseCoordinator):
                 "events",
                 self._on_websocket_event_message,
                 reconnect=True,
-                on_connection_state_change=self._on_websocket_connection_state_change,
+                on_connection_state_change=self._on_events_connection_state_change,
             ),
             name=f"{DOMAIN}_protect_websocket_events",
         )
@@ -321,7 +339,7 @@ class UnifiProtectCoordinator(UnifiBaseCoordinator):
         are still merged in full, since a real device "type" field nested
         under one of those is legitimate data, not envelope noise.
         """
-        self._mark_ws_frame_received()
+        self._mark_ws_frame_received("devices")
 
         if not isinstance(message, dict):
             self._log_unparseable_ws_message(
@@ -387,46 +405,119 @@ class UnifiProtectCoordinator(UnifiBaseCoordinator):
         _LOGGER.log(level, msg, *args)
         setattr(self, warned_attr, True)
 
-    def _mark_ws_frame_received(self) -> None:
+    def _mark_ws_frame_received(self, stream: str) -> None:
         """
-        Record that a WebSocket frame was just delivered (task 5).
+        Record that a WebSocket frame was just delivered on `stream` (task 5).
 
+        Hardened by review finding 1 to be per-subscription, not shared.
         Called unconditionally at the top of both adapters, even for a
         frame that turns out to be unparseable - receiving anything at all
-        is evidence the wire is alive, which is exactly the "connected but
-        silent" vs. "delivering" distinction `websocket_health` exists to
-        answer.
+        is evidence that stream's wire is alive, which is exactly the
+        "connected but silent" vs. "delivering" distinction
+        `websocket_health` exists to answer. Only `stream`'s own entry in
+        `_ws_stream_health` is touched, so a chatty devices stream can never
+        make a silent events stream look alive, or vice versa.
         """
-        self._last_ws_message = datetime.now(UTC)
-        self._ws_connected = True
+        self._ws_stream_health[stream]["last_message_at"] = datetime.now(UTC)
+        self._ws_stream_health[stream]["connected"] = True
+        self._recompute_ws_health_rollup()
 
     @callback
-    def _on_websocket_connection_state_change(self, connected: bool) -> None:  # noqa: FBT001
-        # ^ positional bool is required here: this is registered as
-        # ProtectWebSocket.subscribe_with_callback's `on_connection_state_change`
-        # and invoked positionally to match `Callable[[bool], None]`.
+    def _on_devices_connection_state_change(self, connected: bool) -> None:  # noqa: FBT001
         """
-        Track WS connect/reconnect/disconnect transitions.
+        Adapt the devices subscription's connect/disconnect callback.
 
-        Drives two things: the `_ws_connected` half of the health signal
-        (task 5), and stale-latch reconciliation on every (re)connect
-        (task 2) - a reconnect means the subscription was down for some
-        stretch of time during which an "end" frame could have been
-        missed entirely, so waiting for the next 30s REST poll to notice
-        would leave a latched sensor ON longer than necessary.
+        See `_on_websocket_connection_state_change`; kept as its own bound
+        method (rather than e.g. `functools.partial`) so it still satisfies
+        `ProtectWebSocket.subscribe_with_callback`'s `Callable[[bool], None]`
+        contract exactly.
         """
-        self._ws_connected = connected
+        self._on_websocket_connection_state_change("devices", connected=connected)
+
+    @callback
+    def _on_events_connection_state_change(self, connected: bool) -> None:  # noqa: FBT001
+        """
+        Adapt the events subscription's connect/disconnect callback.
+
+        See `_on_devices_connection_state_change`.
+        """
+        self._on_websocket_connection_state_change("events", connected=connected)
+
+    @callback
+    def _on_websocket_connection_state_change(
+        self, stream: str, *, connected: bool
+    ) -> None:
+        """
+        Track WS connect/reconnect/disconnect transitions for `stream`.
+
+        `stream` is "devices" or "events" - each subscription is registered
+        with its own bound wrapper (`_on_devices_connection_state_change` /
+        `_on_events_connection_state_change`) so this always knows which one
+        transitioned, rather than the two subscriptions clobbering one
+        shared flag (review finding 1: that let a devices-only reconnect
+        read identically to a full recovery while the events subscription
+        stayed hung).
+
+        Drives two things: the per-stream half of the health signal
+        (task 5), and stale-latch reconciliation on every (re)connect of
+        EITHER stream (task 2) - a reconnect means that subscription was
+        down for some stretch of time during which an "end" frame could
+        have been missed entirely, so waiting for the next 30s REST poll to
+        notice would leave a latched sensor ON longer than necessary.
+        """
+        self._ws_stream_health[stream]["connected"] = connected
+        self._recompute_ws_health_rollup()
         if connected:
             self._reconcile_stale_events()
 
+    def _recompute_ws_health_rollup(self) -> None:
+        """
+        Recompute the top-level `_ws_connected`/`_last_ws_message` roll-up.
+
+        `_ws_connected` is True only when BOTH the devices and events
+        streams are connected - the whole point of review finding 1 is that
+        a half-dead pair (one stream healthy, one hung) must read as
+        unhealthy at the top level too, not just in the per-stream detail
+        that a human has to know to go look for. `_last_ws_message` stays
+        the most recent frame from EITHER stream, preserving the original
+        "is the wire alive at all" coarse-liveness semantics as a secondary
+        signal.
+        """
+        streams = self._ws_stream_health.values()
+        self._ws_connected = all(s["connected"] for s in streams)
+        timestamps = [s["last_message_at"] for s in streams if s["last_message_at"]]
+        self._last_ws_message = max(timestamps) if timestamps else None
+
     @property
     def websocket_health(self) -> dict[str, Any]:
-        """Expose WS connectivity/delivery health for diagnostics.py (task 5)."""
+        """
+        Expose WS connectivity/delivery health for diagnostics.py (task 5).
+
+        Surfaces BOTH a top-level roll-up (`connected`/`last_message_at`,
+        same key names as before this fix - review finding 1 asked to
+        preserve these where cheap so any existing consumer/dashboard
+        keeps working) AND per-subscription detail under `devices`/`events`,
+        since the top-level pair alone cannot distinguish "both streams
+        healthy" from "devices healthy, events silently hung" - exactly the
+        failure this signal exists to catch.
+        """
+
+        def _stream_payload(stream: dict[str, Any]) -> dict[str, Any]:
+            last_message_at = stream["last_message_at"]
+            return {
+                "connected": stream["connected"],
+                "last_message_at": (
+                    last_message_at.isoformat() if last_message_at else None
+                ),
+            }
+
         return {
             "connected": self._ws_connected,
             "last_message_at": (
                 self._last_ws_message.isoformat() if self._last_ws_message else None
             ),
+            "devices": _stream_payload(self._ws_stream_health["devices"]),
+            "events": _stream_payload(self._ws_stream_health["events"]),
         }
 
     @callback
@@ -571,7 +662,7 @@ class UnifiProtectCoordinator(UnifiBaseCoordinator):
         holds the real fields - there is no separate envelope to strip in
         that shape, so it is used directly.
         """
-        self._mark_ws_frame_received()
+        self._mark_ws_frame_received("events")
 
         if not isinstance(message, dict):
             self._log_unparseable_ws_message(
@@ -935,6 +1026,40 @@ class UnifiProtectCoordinator(UnifiBaseCoordinator):
                     camera.get("smartDetectTypes", []),
                 )
         self.data["cameras"] = cameras
+        self._drop_rebuilt_latch_trackers(cameras)
+
+    def _drop_rebuilt_latch_trackers(self, cameras: dict[str, Any]) -> None:
+        """
+        Pop event-derived latch trackers whose backing field vanished under them.
+
+        `_fetch_cameras()` wholesale-replaces `self.data["cameras"]` every
+        ~30s from REST models that carry no `lastMotionStart`/`lastRingStart`
+        field at all - those are only ever written by a paired WebSocket
+        "start" event (see `_apply_motion_event`/`_apply_ring_event`), never
+        by the REST API (confirmed: api/protect/models/camera.py declares
+        neither field). Without this, a still-armed tracker survives the
+        rebuild pointing at a camera dict that now has no "start" (or "end")
+        field either, and ~5 minutes later `_reconcile_stale_events` treats
+        that as an orphaned latch and logs a false "missed 'end' event?"
+        warning - even though the latch was already correctly cleared by
+        this exact REST poll 4m30s earlier. This fires on virtually every
+        real motion/ring event (the common "start"-only frame), flooding
+        INFO logs during exactly the window someone is watching them to
+        confirm a deploy worked.
+
+        Only pops when the camera is still present but has lost the field
+        entirely; a camera that vanished outright is left to the existing
+        "removed device" handling in `_expire_stale_latch`.
+        """
+        for device_id in list(self._camera_motion_started):
+            camera = cameras.get(device_id)
+            if isinstance(camera, dict) and "lastMotionStart" not in camera:
+                self._camera_motion_started.pop(device_id, None)
+
+        for device_id in list(self._camera_ring_started):
+            camera = cameras.get(device_id)
+            if isinstance(camera, dict) and "lastRingStart" not in camera:
+                self._camera_ring_started.pop(device_id, None)
 
     async def _fetch_lights(self) -> None:
         """Fetch light data."""

--- a/custom_components/unifi_insights/coordinators/protect.py
+++ b/custom_components/unifi_insights/coordinators/protect.py
@@ -31,6 +31,8 @@ from custom_components.unifi_insights.const import (
 from .base import UnifiBaseCoordinator
 
 if TYPE_CHECKING:
+    import asyncio
+
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import HomeAssistant
 
@@ -61,6 +63,7 @@ class UnifiProtectCoordinator(UnifiBaseCoordinator):
         network_client: UniFiNetworkClient,
         protect_client: UniFiProtectClient | None,
         entry: ConfigEntry,
+        site_id: str = "default",
     ) -> None:
         """Initialize the Protect coordinator."""
         super().__init__(
@@ -95,33 +98,93 @@ class UnifiProtectCoordinator(UnifiBaseCoordinator):
             "last_update": None,
         }
 
-        # Register WebSocket callbacks if Protect API is available
-        if self.protect_client:
-            self._setup_websocket_callbacks()
+        # Site ID used for WebSocket subscriptions (ignored for LOCAL REST
+        # calls, kept here for REMOTE/cloud routing - see
+        # ProtectWebSocket._subscribe_path).
+        self._site_id = site_id
 
-    def _setup_websocket_callbacks(self) -> None:
-        """Set up WebSocket callbacks for real-time updates."""
-        if not self.protect_client:
+        # Populated by async_start_websocket(); the background task handle is
+        # read by __init__.py's async_unload_entry to cancel the WebSocket
+        # loop on unload/reload.
+        self.websocket_task: asyncio.Task[None] | None = None
+        self._protect_websocket: Any = (
+            self.protect_client.websocket if self.protect_client else None
+        )
+
+    async def async_start_websocket(self) -> None:
+        """
+        Start the real-time Protect WebSocket subscription.
+
+        This is additive to the 30 second poll (SCAN_INTERVAL_PROTECT), which
+        remains the fallback if the WebSocket is unavailable or drops - it is
+        never removed by this method. Any failure here is logged and
+        swallowed so a WebSocket problem never blocks integration setup or
+        leaves the coordinator without its polling fallback.
+        """
+        if not self.protect_client or not self._protect_websocket:
+            return
+        if self.websocket_task is not None and not self.websocket_task.done():
+            _LOGGER.debug("Protect coordinator: WebSocket already running")
             return
 
         try:
-            registered = False
-            if hasattr(self.protect_client, "register_device_update_callback"):
-                self.protect_client.register_device_update_callback(
-                    self._handle_device_update
-                )
-                registered = True
-            if hasattr(self.protect_client, "register_event_update_callback"):
-                self.protect_client.register_event_update_callback(
-                    self._handle_event_update
-                )
-                registered = True
-            if registered:
-                _LOGGER.debug("Protect coordinator: WebSocket callbacks registered")
+            host_id = await self.protect_client.get_host_id()
         except Exception as err:
-            _LOGGER.debug(
-                "Protect coordinator: WebSocket callbacks not supported: %s", err
+            _LOGGER.warning(
+                "Protect coordinator: Unable to resolve host_id for WebSocket "
+                "subscription, falling back to %s polling only: %s",
+                SCAN_INTERVAL_PROTECT,
+                err,
             )
+            return
+
+        self.websocket_task = self.hass.async_create_background_task(
+            self._protect_websocket.subscribe_with_callback(
+                host_id,
+                self._site_id,
+                "devices",
+                self._on_websocket_message,
+                reconnect=True,
+            ),
+            name=f"{DOMAIN}_protect_websocket",
+        )
+        _LOGGER.debug(
+            "Protect coordinator: WebSocket subscription started (host_id=%s, "
+            "site_id=%s)",
+            host_id,
+            self._site_id,
+        )
+
+    @callback
+    def _on_websocket_message(self, message: dict[str, Any]) -> None:
+        """
+        Adapt a raw WebSocket "devices" message to `_handle_device_update`.
+
+        The message may carry the device fields at the top level or nested
+        under a "payload" key, and the model key may be `modelKey` (API
+        camelCase) or `model_key`. Anything that doesn't parse is logged at
+        warning level rather than dropped silently, since a swallowed frame
+        here is a missed device state change (e.g. a door sensor opening).
+        """
+        if not isinstance(message, dict):
+            _LOGGER.warning(
+                "Protect coordinator: WebSocket message was not a JSON object: %r",
+                message,
+            )
+            return
+
+        payload = message.get("payload")
+        device_data = payload if isinstance(payload, dict) else message
+
+        model_key = device_data.get("modelKey") or device_data.get("model_key")
+        if not model_key:
+            _LOGGER.warning(
+                "Protect coordinator: WebSocket device message missing modelKey: %s",
+                message,
+            )
+            return
+
+        self._handle_device_update(model_key, device_data)
 
     @callback
     def _handle_device_update(
@@ -181,7 +244,12 @@ class UnifiProtectCoordinator(UnifiBaseCoordinator):
                 **device_data,
             }
 
-        self.async_update_listeners()
+        # async_set_updated_data (rather than async_update_listeners) also
+        # marks the last update as successful and resets the poll timer, so
+        # entities relying on last_update_success don't stay unavailable
+        # while WebSocket data is flowing, and the 30s poll fallback re-arms
+        # from the last WebSocket message rather than firing needlessly.
+        self.async_set_updated_data(self.data)
 
     def _normalize_camera_data(self, camera: dict[str, Any]) -> dict[str, Any]:
         """Normalize camera fields across alias and legacy payload shapes."""

--- a/custom_components/unifi_insights/coordinators/protect.py
+++ b/custom_components/unifi_insights/coordinators/protect.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-from datetime import UTC, datetime
 import logging
-from typing import TYPE_CHECKING, Any
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Any, Final
 
 from homeassistant.core import callback
 from homeassistant.helpers import device_registry as dr
@@ -41,6 +41,49 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+# Bounded auto-off for the event-derived motion/smart-detect/ring latch (see
+# `_reconcile_stale_events`). Protect gives no delivery guarantee on the
+# "end" frame that closes out a motion/smartDetect/ring event (a WS
+# reconnect, a dropped frame, a network glitch can all lose it), and the
+# `camera_motion`/`camera_*_detection` binary sensors turn ON purely from
+# "start seen, end not yet seen" - so a missing "end" would otherwise latch
+# them ON forever. In a home security system a permanently-ON motion sensor
+# is worse than one that never fires: it destroys the signal and can trigger
+# automations or wake people up endlessly.
+#
+# Five minutes is chosen as an order-of-magnitude safety margin: it is well
+# above SCAN_INTERVAL_PROTECT (30s, so it never fires on ordinary poll
+# jitter) and well above a realistic single continuous Protect motion/smart
+# -detect/doorbell-ring event (typically seconds to low minutes), while
+# still being short enough that a stuck sensor self-heals within single
+# -digit minutes rather than staying wrong for hours. It is deliberately not
+# tied to any one event type - see `_reconcile_stale_events`.
+STALE_EVENT_TIMEOUT: Final = timedelta(minutes=5)
+
+# Envelope-only keys that must never leak from the raw top-level WebSocket
+# frame into a merged device/event dict - see `_pick_field` and the
+# `_on_websocket_message`/`_on_websocket_event_message` docstrings for why.
+_ENVELOPE_ONLY_KEYS: Final = frozenset({"type", "action", "payload", "item"})
+
+
+def _pick_field(containers: list[dict[str, Any]], *keys: str) -> Any:
+    """
+    Return the first truthy value for any of `keys`, in container order.
+
+    Shared by both WebSocket adapters: a real frame's identifying fields
+    (modelKey/id for devices, type/id for events) may live at the top
+    level, under "item", under "payload", or split across an "action"
+    header - trying every plausible container/key combination instead of
+    picking one and giving up avoids silently dropping every real frame if
+    the guess is wrong.
+    """
+    for container in containers:
+        for key in keys:
+            value = container.get(key)
+            if value:
+                return value
+    return None
+
 
 class UnifiProtectCoordinator(UnifiBaseCoordinator):
     """
@@ -55,6 +98,19 @@ class UnifiProtectCoordinator(UnifiBaseCoordinator):
     - Chimes
     - Liveviews
     - Real-time events via WebSocket
+
+    UNVALIDATED SCHEMA WARNING: the "events" WebSocket subscription
+    (`_on_websocket_event_message` / `_handle_event_update` /
+    `_process_event_for_device`) has never executed against real Protect
+    traffic before this coordinator started subscribing to it. Every frame
+    -shape assumption in that path (envelope shape, which key carries the
+    device id, whether "smartDetectZone" or "smartDetect" is the real
+    smart-detect event type) is a best-effort guess pending a real capture
+    - see the inline UNVALIDATED comments at each guess. The whole path is
+    written to degrade safely if a guess is wrong: it never raises into the
+    WS callback, it logs an unparseable frame once at WARNING then at
+    DEBUG, and it never latches a binary sensor on indefinitely (see
+    `STALE_EVENT_TIMEOUT` / `_reconcile_stale_events`).
     """
 
     def __init__(
@@ -103,17 +159,46 @@ class UnifiProtectCoordinator(UnifiBaseCoordinator):
         # ProtectWebSocket._subscribe_path).
         self._site_id = site_id
 
-        # Populated by async_start_websocket(); the background task handle is
-        # read by __init__.py's async_unload_entry to cancel the WebSocket
-        # loop on unload/reload.
+        # Populated by async_start_websocket(); the background task handles
+        # are read by __init__.py's async_unload_entry to cancel the
+        # WebSocket loops on unload/reload. Two independent subscriptions -
+        # "devices" (websocket_task) and "events" (events_websocket_task) -
+        # run concurrently on the same ProtectWebSocket instance.
         self.websocket_task: asyncio.Task[None] | None = None
+        self.events_websocket_task: asyncio.Task[None] | None = None
         self._protect_websocket: Any = (
             self.protect_client.websocket if self.protect_client else None
         )
-        # Caps the "can't parse WebSocket message" warning to once, so a
-        # persistently wrong frame shape can't log-storm a production
-        # instance; every subsequent occurrence still logs at debug.
+        # Caps the "can't parse WebSocket message" warning to once per
+        # stream, so a persistently wrong frame shape can't log-storm a
+        # production instance; every subsequent occurrence still logs at
+        # debug. Devices and events are tracked separately since they are
+        # different failure classes.
         self._ws_parse_warned = False
+        self._ws_event_parse_warned = False
+
+        # WebSocket health signal (task 5): there was previously no way to
+        # tell "connected and delivering" from "connected but silent" from
+        # "reconnect-looping" - surfaced via `websocket_health` in
+        # diagnostics.py. `_last_ws_message` updates on ANY inbound frame
+        # (devices or events, even an unparseable one - receiving anything
+        # is evidence the wire is alive); `_ws_connected` mirrors the
+        # underlying ProtectWebSocket connect/disconnect transitions
+        # (combined across both subscriptions - see
+        # `_on_websocket_connection_state_change`).
+        self._last_ws_message: datetime | None = None
+        self._ws_connected: bool = False
+
+        # Wall-clock (HA-local, not Protect's) time each camera/light/ring
+        # latch became active (event "start" seen, "end" not yet seen).
+        # Deliberately independent of the event payload's own start/end
+        # timestamp format (unconfirmed - see class docstring) so the
+        # STALE_EVENT_TIMEOUT auto-off in `_reconcile_stale_events` never
+        # depends on that guess being right. Popped as soon as a real "end"
+        # arrives; see `_apply_motion_event` / `_apply_ring_event`.
+        self._camera_motion_started: dict[str, datetime] = {}
+        self._light_motion_started: dict[str, datetime] = {}
+        self._camera_ring_started: dict[str, datetime] = {}
 
     async def async_start_websocket(self) -> None:
         """
@@ -149,11 +234,31 @@ class UnifiProtectCoordinator(UnifiBaseCoordinator):
                 "devices",
                 self._on_websocket_message,
                 reconnect=True,
+                on_connection_state_change=self._on_websocket_connection_state_change,
             ),
             name=f"{DOMAIN}_protect_websocket",
         )
+        # Second, independent subscription (task 1 - the actual fix): without
+        # this, `_handle_event_update`/`_process_event_for_device` have no
+        # caller anywhere, so `lastMotionStart`/`lastMotionEnd`/
+        # `lastSmartDetectTypes` are never written and every motion/smart
+        # -detect binary sensor is permanently OFF. Runs on the same
+        # ProtectWebSocket instance as the devices subscription above -
+        # `ProtectWebSocket._running` is a single shared gate, so a shared
+        # `stop()` call (see async_stop_websocket) correctly ends both.
+        self.events_websocket_task = self.hass.async_create_background_task(
+            self._protect_websocket.subscribe_with_callback(
+                host_id,
+                self._site_id,
+                "events",
+                self._on_websocket_event_message,
+                reconnect=True,
+                on_connection_state_change=self._on_websocket_connection_state_change,
+            ),
+            name=f"{DOMAIN}_protect_websocket_events",
+        )
         _LOGGER.debug(
-            "Protect coordinator: WebSocket subscription started (host_id=%s, "
+            "Protect coordinator: WebSocket subscriptions started (host_id=%s, "
             "site_id=%s)",
             host_id,
             self._site_id,
@@ -161,14 +266,18 @@ class UnifiProtectCoordinator(UnifiBaseCoordinator):
 
     async def async_stop_websocket(self) -> None:
         """
-        Stop the WebSocket subscription and await its background task.
+        Stop both WebSocket subscriptions and await their background tasks.
 
         Safe to call when the WebSocket was never started. Signals the
         `ProtectWebSocket` loop to stop reconnecting *before* cancelling the
         task, then awaits the cancellation - `cancel()` alone leaves the
         reconnect loop free to spin back up, and the loop being parked in
         `async for msg in ws` means `stop()` alone won't unblock it either;
-        both are needed to avoid an orphaned WebSocket loop.
+        both are needed to avoid an orphaned WebSocket loop. `stop()` is
+        called once (it flips a single flag shared by both subscriptions on
+        the same ProtectWebSocket instance - see async_start_websocket) and
+        applies to both the devices and events tasks, which are then each
+        cancelled and awaited in turn using that same ordering.
 
         Registered with `entry.async_on_unload()` (covers a setup failure
         that happens after the WebSocket started but before setup
@@ -177,12 +286,12 @@ class UnifiProtectCoordinator(UnifiBaseCoordinator):
         """
         if self._protect_websocket:
             self._protect_websocket.stop()
-        task = self.websocket_task
-        if task:
-            task.cancel()
-            if isinstance(task, asyncio.Task):
-                with contextlib.suppress(asyncio.CancelledError, Exception):
-                    await task
+        for task in (self.websocket_task, self.events_websocket_task):
+            if task:
+                task.cancel()
+                if isinstance(task, asyncio.Task):
+                    with contextlib.suppress(asyncio.CancelledError, Exception):
+                        await task
 
     @callback
     def _on_websocket_message(self, message: dict[str, Any]) -> None:
@@ -198,7 +307,22 @@ class UnifiProtectCoordinator(UnifiBaseCoordinator):
         app WebSocket) - rather than picking one container and giving up.
         Picking a single container wrong would silently drop every real
         frame, which for a door sensor means a missed open/close event.
+
+        The raw envelope (`message`) is included as a last-resort container
+        so a fully flat frame (no item/payload/action wrapper) still works,
+        but its own "type"/"action"/"payload"/"item" keys are stripped
+        before merging - confirmed in production: without that exclusion,
+        the envelope's "type": "update" (the action verb, not a device
+        field) clobbered the real hardware model string (UFP-SENSE,
+        USL-Entry-US, USL-Environmental-US) on any partial update frame
+        that didn't re-send the unchanged "type" field, flipping it back
+        and forth against the next REST poll (measured 49 times in 10
+        minutes). Only `message` is filtered this way - item/payload/action
+        are still merged in full, since a real device "type" field nested
+        under one of those is legitimate data, not envelope noise.
         """
+        self._mark_ws_frame_received()
+
         if not isinstance(message, dict):
             self._log_unparseable_ws_message(
                 "Protect coordinator: WebSocket message was not a JSON object: %r",
@@ -213,14 +337,7 @@ class UnifiProtectCoordinator(UnifiBaseCoordinator):
             c for c in (payload, action, item, message) if isinstance(c, dict)
         ]
 
-        def _pick(key_camel: str, key_snake: str) -> Any:
-            for container in containers:
-                value = container.get(key_camel) or container.get(key_snake)
-                if value:
-                    return value
-            return None
-
-        model_key = _pick("modelKey", "model_key")
+        model_key = _pick_field(containers, "modelKey", "model_key")
         if not model_key:
             self._log_unparseable_ws_message(
                 "Protect coordinator: WebSocket device message missing modelKey: %s",
@@ -228,7 +345,7 @@ class UnifiProtectCoordinator(UnifiBaseCoordinator):
             )
             return
 
-        device_id = _pick("id", "id")
+        device_id = _pick_field(containers, "id")
         if not device_id:
             _LOGGER.debug(
                 "Protect coordinator: WebSocket %s update missing device id: %s",
@@ -237,20 +354,80 @@ class UnifiProtectCoordinator(UnifiBaseCoordinator):
             )
             return
 
-        # Merge every dict container so fields split across payload/action
-        # (e.g. id in the header, state fields in the payload) are all kept.
+        # Merge every dict container into a brand-new dict (never mutating
+        # `self.data` or any container in place - in-place mutation can
+        # make HA listeners holding a stale reference miss the transition)
+        # so fields split across payload/action (e.g. id in the header,
+        # state fields in the payload) are all kept.
         device_data: dict[str, Any] = {}
         for container in reversed(containers):
-            device_data.update(container)
+            if container is message:
+                device_data.update(
+                    {k: v for k, v in container.items() if k not in _ENVELOPE_ONLY_KEYS}
+                )
+            else:
+                device_data.update(container)
         device_data["id"] = device_id
 
         self._handle_device_update(model_key, device_data)
 
-    def _log_unparseable_ws_message(self, msg: str, *args: Any) -> None:
-        """Log an unparseable WS message once at WARNING, then at DEBUG."""
-        level = logging.WARNING if not self._ws_parse_warned else logging.DEBUG
+    def _log_unparseable_ws_message(
+        self, msg: str, *args: Any, event_stream: bool = False
+    ) -> None:
+        """
+        Log an unparseable WS message once at WARNING, then at DEBUG.
+
+        `event_stream` selects an independent warned-once flag for the
+        "events" subscription so a persistently-wrong events frame shape
+        (see class docstring) doesn't share its one-time WARNING with the
+        unrelated "devices" subscription, or vice versa.
+        """
+        warned_attr = "_ws_event_parse_warned" if event_stream else "_ws_parse_warned"
+        level = logging.WARNING if not getattr(self, warned_attr) else logging.DEBUG
         _LOGGER.log(level, msg, *args)
-        self._ws_parse_warned = True
+        setattr(self, warned_attr, True)
+
+    def _mark_ws_frame_received(self) -> None:
+        """
+        Record that a WebSocket frame was just delivered (task 5).
+
+        Called unconditionally at the top of both adapters, even for a
+        frame that turns out to be unparseable - receiving anything at all
+        is evidence the wire is alive, which is exactly the "connected but
+        silent" vs. "delivering" distinction `websocket_health` exists to
+        answer.
+        """
+        self._last_ws_message = datetime.now(UTC)
+        self._ws_connected = True
+
+    @callback
+    def _on_websocket_connection_state_change(self, connected: bool) -> None:  # noqa: FBT001
+        # ^ positional bool is required here: this is registered as
+        # ProtectWebSocket.subscribe_with_callback's `on_connection_state_change`
+        # and invoked positionally to match `Callable[[bool], None]`.
+        """
+        Track WS connect/reconnect/disconnect transitions.
+
+        Drives two things: the `_ws_connected` half of the health signal
+        (task 5), and stale-latch reconciliation on every (re)connect
+        (task 2) - a reconnect means the subscription was down for some
+        stretch of time during which an "end" frame could have been
+        missed entirely, so waiting for the next 30s REST poll to notice
+        would leave a latched sensor ON longer than necessary.
+        """
+        self._ws_connected = connected
+        if connected:
+            self._reconcile_stale_events()
+
+    @property
+    def websocket_health(self) -> dict[str, Any]:
+        """Expose WS connectivity/delivery health for diagnostics.py (task 5)."""
+        return {
+            "connected": self._ws_connected,
+            "last_message_at": (
+                self._last_ws_message.isoformat() if self._last_ws_message else None
+            ),
+        }
 
     @callback
     def _handle_device_update(
@@ -371,6 +548,87 @@ class UnifiProtectCoordinator(UnifiBaseCoordinator):
         return normalized
 
     @callback
+    def _on_websocket_event_message(self, message: dict[str, Any]) -> None:
+        """
+        Adapt a raw WebSocket "events" message to `_handle_event_update`.
+
+        UNVALIDATED against live traffic (see class docstring): this
+        subscription has never received a real Protect "events" frame, so
+        the envelope shape assumed here - mirroring the confirmed "devices"
+        envelope (payload/item/action splits, see `_on_websocket_message`)
+        - is a best-effort guess pending a real capture. Every extraction
+        is deliberately tolerant (multiple candidate keys, never raises) so
+        a wrong guess degrades to a dropped/logged frame instead of a crash
+        or a wedged coordinator.
+
+        The event's own "type" (motion/smartDetect/ring) is resolved only
+        from an inner item/payload/action container when one is present -
+        deliberately excluding the raw envelope `message`, whose top-level
+        "type" would otherwise be the envelope action verb ("add"/
+        "update"), not the Protect event type (see the identical "type"
+        -clobbering fix in `_on_websocket_message`). When no inner
+        container exists at all, the frame is flat and `message` itself
+        holds the real fields - there is no separate envelope to strip in
+        that shape, so it is used directly.
+        """
+        self._mark_ws_frame_received()
+
+        if not isinstance(message, dict):
+            self._log_unparseable_ws_message(
+                "Protect coordinator: WebSocket event message was not a JSON "
+                "object: %r",
+                message,
+                event_stream=True,
+            )
+            return
+
+        payload = message.get("payload")
+        item = message.get("item")
+        action = message.get("action")
+        containers = [c for c in (payload, item, action) if isinstance(c, dict)]
+        if not containers:
+            containers = [message]
+
+        event_type = _pick_field(containers, "type", "eventType", "event_type")
+        if not event_type:
+            self._log_unparseable_ws_message(
+                "Protect coordinator: WebSocket event message missing event type: %s",
+                message,
+                event_stream=True,
+            )
+            return
+
+        event_id = _pick_field([*containers, message], "id")
+        if not event_id:
+            _LOGGER.debug(
+                "Protect coordinator: WebSocket %s event missing event id: %s",
+                event_type,
+                message,
+            )
+            return
+
+        # New dict, never mutating a container in place (same rationale as
+        # _on_websocket_message).
+        event_data: dict[str, Any] = {}
+        for container in reversed(containers):
+            event_data.update(container)
+        event_data["id"] = event_id
+
+        try:
+            self._handle_event_update(event_type, event_data)
+        except Exception:
+            # This whole path has never executed against real traffic
+            # (class docstring) - never let a wrong schema assumption take
+            # down the WS reconnect loop. STALE_EVENT_TIMEOUT reconciliation
+            # is the real backstop for a dropped/misparsed frame, not this
+            # try/except - this only guarantees the frame doesn't crash us.
+            _LOGGER.exception(
+                "Protect coordinator: unexpected error processing WebSocket "
+                "%s event frame; dropping it and continuing",
+                event_type,
+            )
+
+    @callback
     def _handle_event_update(self, event_type: str, event_data: dict[str, Any]) -> None:
         """Handle event update from WebSocket."""
         event_id = event_data.get("id")
@@ -389,8 +647,25 @@ class UnifiProtectCoordinator(UnifiBaseCoordinator):
 
         self.data["events"][event_type][event_id] = event_data
 
-        # Update device last event time if applicable
-        device_id = event_data.get("device")
+        # UNVALIDATED (see class docstring): api/protect/models/event.py's
+        # `Event` model has no generic "device" field - only camera/
+        # cameraId or sensor/sensorId. "device" is checked first to keep
+        # existing direct-call tests/behavior unchanged; the rest are
+        # tolerated so a real frame using the model's actual field names
+        # still resolves instead of `_process_event_for_device` silently
+        # never being called (confirmed dead code before this fix).
+        device_id = _pick_field(
+            [event_data],
+            "device",
+            "camera",
+            "cameraId",
+            "camera_id",
+            "sensor",
+            "sensorId",
+            "sensor_id",
+            "deviceId",
+            "device_id",
+        )
         if device_id:
             self._process_event_for_device(event_type, event_data, device_id)
 
@@ -402,9 +677,9 @@ class UnifiProtectCoordinator(UnifiBaseCoordinator):
         """Process event data and update relevant device."""
         # Check if this is a camera motion event
         if event_type == "motion" and device_id in self.data["cameras"]:
-            self.data["cameras"][device_id]["lastMotionStart"] = event_data.get("start")
-            self.data["cameras"][device_id]["lastMotionEnd"] = event_data.get("end")
-            self.data["cameras"][device_id]["lastSmartDetectTypes"] = []
+            self._apply_motion_event(
+                self.data["cameras"], device_id, event_data, self._camera_motion_started
+            )
             _LOGGER.info(
                 "Protect coordinator: Motion event for camera %s: start=%s, end=%s",
                 device_id,
@@ -414,17 +689,30 @@ class UnifiProtectCoordinator(UnifiBaseCoordinator):
 
         # Check if this is a light motion event
         elif event_type == "motion" and device_id in self.data["lights"]:
-            self.data["lights"][device_id]["lastMotionStart"] = event_data.get("start")
-            self.data["lights"][device_id]["lastMotionEnd"] = event_data.get("end")
+            self._apply_motion_event(
+                self.data["lights"], device_id, event_data, self._light_motion_started
+            )
 
         # Check if this is a smart detection event
-        elif event_type == "smartDetectZone" and device_id in self.data["cameras"]:
+        elif (
+            # UNVALIDATED (see class docstring): models/event.py's
+            # EventType enum defines SMART_DETECT = "smartDetect", but this
+            # integration's original code compared only against
+            # "smartDetectZone" - unconfirmed which (or both, e.g. a
+            # zone-specific sub-event vs. the general type) a real frame
+            # actually sends, so both are accepted rather than guessing.
+            event_type in ("smartDetectZone", "smartDetect")
+            and device_id in self.data["cameras"]
+        ):
             smart_detect_types = event_data.get("smartDetectTypes", [])
+            if not isinstance(smart_detect_types, list):
+                smart_detect_types = []
             event_start = event_data.get("start", 0)
             event_end = event_data.get("end")
 
-            self.data["cameras"][device_id]["lastMotionStart"] = event_start
-            self.data["cameras"][device_id]["lastMotionEnd"] = event_end
+            self._apply_motion_event(
+                self.data["cameras"], device_id, event_data, self._camera_motion_started
+            )
             self.data["cameras"][device_id]["lastSmartDetectTypes"] = smart_detect_types
 
             _LOGGER.info(
@@ -438,14 +726,121 @@ class UnifiProtectCoordinator(UnifiBaseCoordinator):
 
         # Check if this is a doorbell ring event
         elif event_type == "ring" and device_id in self.data["cameras"]:
-            self.data["cameras"][device_id]["lastRingStart"] = event_data.get("start")
-            self.data["cameras"][device_id]["lastRingEnd"] = event_data.get("end")
+            self._apply_ring_event(self.data["cameras"], device_id, event_data)
             _LOGGER.info(
                 "Protect coordinator: Doorbell ring for camera %s: start=%s, end=%s",
                 device_id,
                 event_data.get("start"),
                 event_data.get("end"),
             )
+
+    def _apply_motion_event(
+        self,
+        bucket: dict[str, Any],
+        device_id: str,
+        event_data: dict[str, Any],
+        tracker: dict[str, datetime],
+    ) -> None:
+        """
+        Write lastMotionStart/lastMotionEnd and track the latch for auto-off.
+
+        Feeds the bounded auto-off in `_reconcile_stale_events` (task 2).
+        Tracking uses HA's own wall clock rather than the event payload's
+        start/end values, so the auto-off timeout is correct regardless of
+        whatever timestamp format/units Protect actually sends (unconfirmed
+        - see class docstring).
+        """
+        end = event_data.get("end")
+        bucket[device_id]["lastMotionStart"] = event_data.get("start")
+        bucket[device_id]["lastMotionEnd"] = end
+        if end is None:
+            tracker.setdefault(device_id, datetime.now(UTC))
+        else:
+            tracker.pop(device_id, None)
+
+    def _apply_ring_event(
+        self, bucket: dict[str, Any], device_id: str, event_data: dict[str, Any]
+    ) -> None:
+        """
+        Write lastRingStart/lastRingEnd and track the latch for auto-off.
+
+        The doorbell ring latch has the identical dropped-"end"-frame risk
+        as motion once the events stream is live, so it gets the same
+        safety net (see `_apply_motion_event`).
+        """
+        end = event_data.get("end")
+        bucket[device_id]["lastRingStart"] = event_data.get("start")
+        bucket[device_id]["lastRingEnd"] = end
+        if end is None:
+            self._camera_ring_started.setdefault(device_id, datetime.now(UTC))
+        else:
+            self._camera_ring_started.pop(device_id, None)
+
+    def _reconcile_stale_events(self) -> None:
+        """
+        Force-expire motion/smart-detect/ring latches held open too long.
+
+        CRITICAL safety net (task 2): `camera_motion`'s ON condition
+        (`isMotionDetected OR (lastMotionStart is not None AND
+        lastMotionEnd is None)`) becomes live the moment the events stream
+        is wired up. Protect gives no delivery guarantee on the "end"
+        frame that closes an event - a WS reconnect, a dropped frame, or a
+        network glitch can lose it - and without this, a missing "end"
+        would latch a motion/person/vehicle/animal/package-detection or
+        doorbell-ring binary sensor ON forever. A permanently-ON motion
+        sensor in a home security system is worse than one that never
+        fires, so this does not trust event pairing alone: it is called
+        from `_async_update_data` (every ~30s REST poll) and from
+        `_on_websocket_connection_state_change` (every WS reconnect), in
+        addition to the normal paired "end" event clearing the latch
+        immediately in `_apply_motion_event`/`_apply_ring_event`.
+        """
+        now = datetime.now(UTC)
+        self._expire_stale_latch(
+            "cameras",
+            self._camera_motion_started,
+            "lastMotionEnd",
+            now,
+            also_clear_key="lastSmartDetectTypes",
+            also_clear_value=[],
+        )
+        self._expire_stale_latch(
+            "lights", self._light_motion_started, "lastMotionEnd", now
+        )
+        self._expire_stale_latch(
+            "cameras", self._camera_ring_started, "lastRingEnd", now
+        )
+
+    def _expire_stale_latch(
+        self,
+        category: str,
+        tracker: dict[str, datetime],
+        end_key: str,
+        now: datetime,
+        *,
+        also_clear_key: str | None = None,
+        also_clear_value: Any = None,
+    ) -> None:
+        """Clear one tracked latch bucket if it has exceeded STALE_EVENT_TIMEOUT."""
+        for device_id in list(tracker):
+            started_at = tracker[device_id]
+            if now - started_at < STALE_EVENT_TIMEOUT:
+                continue
+            device = self.data.get(category, {}).get(device_id)
+            if isinstance(device, dict) and device.get(end_key) is None:
+                _LOGGER.info(
+                    "Protect coordinator: auto-clearing stale %s.%s latch for "
+                    "%s after exceeding the %s safety timeout (missed 'end' "
+                    "event?)",
+                    category,
+                    end_key,
+                    device_id,
+                    STALE_EVENT_TIMEOUT,
+                )
+                device[end_key] = now.isoformat()
+                if also_clear_key is not None:
+                    device[also_clear_key] = also_clear_value
+            tracker.pop(device_id, None)
 
     async def _async_update_data(self) -> dict[str, Any]:
         """Fetch Protect data from API."""
@@ -455,6 +850,12 @@ class UnifiProtectCoordinator(UnifiBaseCoordinator):
 
         try:
             _LOGGER.debug("Protect coordinator: Fetching Protect data")
+
+            # Reconcile stale event-derived latches on every periodic poll
+            # (task 2) - runs against the pre-poll data below, before
+            # _fetch_cameras() rebuilds the cameras dict wholesale from the
+            # REST response.
+            self._reconcile_stale_events()
 
             # Fetch cameras
             await self._fetch_cameras()

--- a/custom_components/unifi_insights/diagnostics.py
+++ b/custom_components/unifi_insights/diagnostics.py
@@ -85,10 +85,19 @@ async def async_get_config_entry_diagnostics(
         "protect_client_connected": coordinator.protect_client is not None,
     }
 
+    # WS health signal (task 5): previously no way to tell "connected and
+    # delivering" from "connected but silent" from "reconnect-looping" -
+    # this is the first place an operator would look for that.
+    protect_coordinator = data.protect_coordinator
+    websocket_info = (
+        protect_coordinator.websocket_health if protect_coordinator else None
+    )
+
     # Get the raw data but remove sensitive information
     diagnostics_data = {
         "library_version": library_version,
         "connection": connection_info,
+        "websocket": websocket_info,
         "entry": async_redact_data(entry.as_dict(), TO_REDACT),
         "data": async_redact_data(coordinator.data, TO_REDACT),
     }

--- a/custom_components/unifi_insights/translations/en.json
+++ b/custom_components/unifi_insights/translations/en.json
@@ -241,6 +241,36 @@
           "off": "Offline"
         }
       },
+      "camera_motion": {
+        "name": "Motion Detection"
+      },
+      "camera_person_detection": {
+        "name": "Person Detection"
+      },
+      "camera_vehicle_detection": {
+        "name": "Vehicle Detection"
+      },
+      "camera_animal_detection": {
+        "name": "Animal Detection"
+      },
+      "camera_package_detection": {
+        "name": "Package Detection"
+      },
+      "camera_doorbell_ring": {
+        "name": "Ring"
+      },
+      "sensor_motion": {
+        "name": "Motion Detection"
+      },
+      "sensor_door": {
+        "name": "Door/Window Status"
+      },
+      "sensor_tamper": {
+        "name": "Tamper Detection"
+      },
+      "sensor_leak": {
+        "name": "Leak Detection"
+      },
       "motion": {
         "name": "Motion"
       },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,9 +166,13 @@ def _create_mock_protect_client() -> MagicMock:
     client.trigger_alarm = AsyncMock(return_value=True)
     client.create_liveview = AsyncMock(return_value={"id": "liveview1"})
     client.update_viewer = AsyncMock(return_value=True)
-    client.register_device_update_callback = MagicMock()
-    client.register_event_update_callback = MagicMock()
-    client.start_websocket = AsyncMock()
+
+    # WebSocket support (real-time device updates, additive to polling)
+    client.get_host_id = AsyncMock(return_value="nvr1")
+    client.websocket = MagicMock()
+    client.websocket.subscribe_with_callback = AsyncMock()
+    client.websocket.stop = MagicMock()
+
     client.close = AsyncMock()
 
     return client

--- a/tests/test_coordinators.py
+++ b/tests/test_coordinators.py
@@ -1218,6 +1218,11 @@ class TestUnifiProtectCoordinator:
         """Test async_start_websocket resolves host_id and starts both the
         devices and events subscriptions (see task 1: the missing events
         subscription is the root cause of motion detection never firing).
+
+        Each subscription is registered with its OWN connection-state
+        callback (review finding 1: a single shared callback couldn't tell
+        the caller which subscription actually transitioned, which is what
+        made a devices-only reconnect look identical to a full recovery).
         """
         coordinator.protect_client.get_host_id = AsyncMock(return_value="nvr1")
         coordinator._protect_websocket.subscribe_with_callback = AsyncMock()
@@ -1236,7 +1241,7 @@ class TestUnifiProtectCoordinator:
             "devices",
             coordinator._on_websocket_message,
             reconnect=True,
-            on_connection_state_change=coordinator._on_websocket_connection_state_change,
+            on_connection_state_change=coordinator._on_devices_connection_state_change,
         )
         coordinator._protect_websocket.subscribe_with_callback.assert_any_await(
             "nvr1",
@@ -1244,7 +1249,7 @@ class TestUnifiProtectCoordinator:
             "events",
             coordinator._on_websocket_event_message,
             reconnect=True,
-            on_connection_state_change=coordinator._on_websocket_connection_state_change,
+            on_connection_state_change=coordinator._on_events_connection_state_change,
         )
         assert coordinator._protect_websocket.subscribe_with_callback.await_count == 2
 
@@ -2238,61 +2243,172 @@ class TestUnifiProtectCoordinator:
     ):
         """Test a WS (re)connect triggers reconciliation - a missed "end"
         frame during the outage would otherwise wait for the next poll.
+
+        Applies per-stream (the callback now needs a `stream` argument -
+        see review finding 1), but a reconnect of EITHER subscription
+        still triggers reconciliation, matching the original behavior.
         """
         with patch.object(coordinator, "_reconcile_stale_events") as mock_reconcile:
-            coordinator._on_websocket_connection_state_change(connected=True)
+            coordinator._on_websocket_connection_state_change(
+                "devices", connected=True
+            )
 
         mock_reconcile.assert_called_once()
 
         with patch.object(
             coordinator, "_reconcile_stale_events"
         ) as mock_reconcile_disconnect:
-            coordinator._on_websocket_connection_state_change(connected=False)
+            coordinator._on_websocket_connection_state_change(
+                "devices", connected=False
+            )
 
         mock_reconcile_disconnect.assert_not_called()
 
     # -- Task 5: WebSocket health signal -------------------------------------
 
     def test_websocket_health_initial_state(self, coordinator: UnifiProtectCoordinator):
-        """Test the WS health signal starts unconnected/unknown."""
+        """Test the WS health signal starts unconnected/unknown, per stream
+        and in the top-level roll-up.
+        """
         assert coordinator._ws_connected is False
         assert coordinator._last_ws_message is None
         assert coordinator.websocket_health == {
             "connected": False,
             "last_message_at": None,
+            "devices": {"connected": False, "last_message_at": None},
+            "events": {"connected": False, "last_message_at": None},
         }
 
     def test_websocket_health_updates_on_devices_frame(
         self, coordinator: UnifiProtectCoordinator
     ):
-        """Test any inbound devices frame marks the socket connected and
-        records when it was last heard from - even an unparseable one,
-        since receiving anything is evidence the wire is alive.
+        """Test an inbound devices frame marks only the devices stream
+        connected - even an unparseable one, since receiving anything is
+        evidence that stream's wire is alive. The top-level roll-up must
+        NOT report overall-healthy off of one stream alone (review finding
+        1): the events subscription is still unknown/disconnected here.
         """
         coordinator._on_websocket_message({"id": "sensor50"})
 
-        assert coordinator._ws_connected is True
+        assert coordinator.websocket_health["devices"]["connected"] is True
+        assert coordinator.websocket_health["devices"]["last_message_at"] is not None
+        assert coordinator.websocket_health["events"]["connected"] is False
+        assert coordinator.websocket_health["events"]["last_message_at"] is None
+
+        assert coordinator._ws_connected is False
+        assert coordinator.websocket_health["connected"] is False
+        # The top-level "any wire alive" timestamp still advances.
         assert coordinator._last_ws_message is not None
-        assert coordinator.websocket_health["connected"] is True
         assert coordinator.websocket_health["last_message_at"] is not None
 
     def test_websocket_health_updates_on_events_frame(
         self, coordinator: UnifiProtectCoordinator
     ):
-        """Test any inbound events frame also marks the socket connected."""
+        """Test an inbound events frame marks only the events stream
+        connected, mirroring the devices case above.
+        """
         coordinator._on_websocket_event_message({"id": "event51"})
 
-        assert coordinator._ws_connected is True
+        assert coordinator.websocket_health["events"]["connected"] is True
+        assert coordinator.websocket_health["events"]["last_message_at"] is not None
+        assert coordinator.websocket_health["devices"]["connected"] is False
+
+        assert coordinator._ws_connected is False
         assert coordinator._last_ws_message is not None
 
     def test_websocket_health_reflects_connection_state_changes(
         self, coordinator: UnifiProtectCoordinator
     ):
-        """Test the connection-state callback directly drives `_ws_connected`."""
-        coordinator._on_websocket_connection_state_change(connected=True)
-        assert coordinator._ws_connected is True
+        """Test the connection-state callback drives per-stream state, and
+        the top-level roll-up only reports connected once BOTH streams are.
+        """
+        coordinator._on_websocket_connection_state_change("devices", connected=True)
+        assert coordinator.websocket_health["devices"]["connected"] is True
+        assert coordinator._ws_connected is False  # events not connected yet
 
-        coordinator._on_websocket_connection_state_change(connected=False)
+        coordinator._on_websocket_connection_state_change("events", connected=True)
+        assert coordinator.websocket_health["events"]["connected"] is True
+        assert coordinator._ws_connected is True  # both streams now connected
+
+        coordinator._on_websocket_connection_state_change("devices", connected=False)
+        assert coordinator.websocket_health["devices"]["connected"] is False
+        assert coordinator.websocket_health["events"]["connected"] is True
+        assert coordinator._ws_connected is False
+
+    def test_on_devices_connection_state_change_updates_devices_stream_only(
+        self, coordinator: UnifiProtectCoordinator
+    ):
+        """Test the bound wrapper registered as the devices subscription's
+        `on_connection_state_change` callback (see `async_start_websocket`)
+        updates only the devices stream's health entry.
+        """
+        coordinator._on_devices_connection_state_change(True)  # noqa: FBT003
+
+        assert coordinator.websocket_health["devices"]["connected"] is True
+        assert coordinator.websocket_health["events"]["connected"] is False
+
+    def test_on_events_connection_state_change_updates_events_stream_only(
+        self, coordinator: UnifiProtectCoordinator
+    ):
+        """Test the bound wrapper registered as the events subscription's
+        `on_connection_state_change` callback updates only the events
+        stream's health entry.
+        """
+        coordinator._on_events_connection_state_change(True)  # noqa: FBT003
+
+        assert coordinator.websocket_health["events"]["connected"] is True
+        assert coordinator.websocket_health["devices"]["connected"] is False
+
+    def test_websocket_health_detects_half_dead_pair(
+        self, coordinator: UnifiProtectCoordinator
+    ):
+        """CRITICAL regression test (review finding 1, Major): a chatty
+        devices subscription must never mask a hung/disconnected events
+        subscription in `websocket_health`.
+
+        This health signal exists specifically to catch "motion silently
+        stopped working for days and nobody noticed" - that failure mode is
+        exactly an NVR restart where the devices stream reconnects cleanly
+        and keeps delivering frames while the events stream hangs half-open
+        (no error, no close frame, just blocked forever). Before this fix,
+        both subscriptions wrote the same shared `_ws_connected`/
+        `_last_ws_message` fields, so devices traffic alone kept
+        `websocket_health` reporting `connected: True` with a fresh
+        `last_message_at` while motion detection was silently dead.
+        """
+        # Devices subscription connects and stays chatty.
+        coordinator._on_websocket_connection_state_change("devices", connected=True)
+        coordinator._on_websocket_message({"id": "sensor52", "modelKey": "sensor"})
+        coordinator._on_websocket_message({"id": "sensor52", "modelKey": "sensor"})
+
+        # Events subscription connected once, then hung - no more frames,
+        # no disconnect callback (that's exactly what a half-open hang
+        # looks like: nothing fires, `async for msg in ws` just blocks).
+        coordinator._on_websocket_connection_state_change("events", connected=True)
+        coordinator._on_websocket_event_message({"id": "event52", "type": "motion"})
+
+        health = coordinator.websocket_health
+
+        # Per-stream detail must show the events stream as connected but
+        # its own traffic is what a human would inspect for staleness -
+        # the critical assertion is that the top-level summary does not
+        # paper over an events-side outage with devices-side traffic.
+        assert health["devices"]["connected"] is True
+        assert health["events"]["connected"] is True
+
+        # Now the events subscription actually drops (half-open hang
+        # eventually surfaces as a connection-state transition once the
+        # heartbeat/reconnect logic in websocket.py notices) while devices
+        # keeps flowing.
+        coordinator._on_websocket_connection_state_change("events", connected=False)
+        coordinator._on_websocket_message({"id": "sensor52", "modelKey": "sensor"})
+
+        health = coordinator.websocket_health
+        assert health["devices"]["connected"] is True
+        assert health["events"]["connected"] is False
+        # The overall roll-up must reflect the outage, not the chatty
+        # devices stream alone.
+        assert health["connected"] is False
         assert coordinator._ws_connected is False
 
     def test_cleanup_stale_devices_no_match(
@@ -2426,6 +2542,87 @@ class TestUnifiProtectCoordinator:
 
         assert "camera3" in coordinator.data["cameras"]
         assert coordinator.data["cameras"]["camera3"]["smartDetectTypes"] == []
+
+    @pytest.mark.asyncio
+    async def test_fetch_cameras_rebuild_drops_motion_tracker_for_fieldless_camera(
+        self,
+        coordinator: UnifiProtectCoordinator,
+        freezer,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        """Test a `_fetch_cameras()` rebuild pops the in-progress motion
+        latch tracker for a camera whose rebuilt dict carries no
+        `lastMotionStart` field, instead of leaving it to be "discovered"
+        stale 5 minutes later.
+
+        Regression test (review finding 2): the REST camera model never
+        carries `lastMotionStart`/`lastMotionEnd` (those are only ever
+        written by a paired WebSocket "start"/"end" event - see
+        `_apply_motion_event`). Before this fix, a `_fetch_cameras()`
+        rebuild silently cleared the latch's own fields without popping the
+        tracker entry, so on virtually every real motion event
+        `_reconcile_stale_events` would later "discover" the orphaned
+        tracker and log a false "missed 'end' event?" warning for motion
+        detection that was already correctly cleared ~4m30s earlier by the
+        REST poll - flooding INFO logs during exactly the window someone is
+        watching them to confirm a deploy worked.
+        """
+        # A live event-derived latch: WebSocket saw a "start" with no "end"
+        # yet, so the tracker is armed - mirrors real motion detection.
+        coordinator.data["cameras"]["camera1"] = {"id": "camera1", "name": "Test"}
+        coordinator._handle_event_update(
+            "motion",
+            {"id": "event49", "device": "camera1", "start": 1, "end": None},
+        )
+        assert "camera1" in coordinator._camera_motion_started
+        assert coordinator.data["cameras"]["camera1"]["lastMotionStart"] == 1
+
+        # The mock protect client's default camera fixture returns
+        # "camera1" but with no lastMotionStart/lastMotionEnd fields at all
+        # (matching the real REST model - see api/protect/models/camera.py).
+        await coordinator._fetch_cameras()
+
+        assert "lastMotionStart" not in coordinator.data["cameras"]["camera1"]
+        assert "camera1" not in coordinator._camera_motion_started
+
+        # 5+ minutes later, the periodic reconciliation safety net must not
+        # find (and log about) a tracker that no longer exists.
+        freezer.tick(STALE_EVENT_TIMEOUT + timedelta(seconds=1))
+        with caplog.at_level(logging.INFO):
+            coordinator._reconcile_stale_events()
+
+        assert "missed 'end' event" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_fetch_cameras_rebuild_drops_ring_tracker_for_fieldless_camera(
+        self,
+        coordinator: UnifiProtectCoordinator,
+        freezer,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        """Test the identical fix also applies to the doorbell ring latch.
+
+        The ring latch is stored on the same per-camera dict that
+        `_fetch_cameras()` wholesale-replaces, so it is exposed to the
+        identical dropped-tracker risk as the motion latch above.
+        """
+        coordinator.data["cameras"]["camera1"] = {"id": "camera1", "name": "Test"}
+        coordinator._handle_event_update(
+            "ring",
+            {"id": "event50", "device": "camera1", "start": 1, "end": None},
+        )
+        assert "camera1" in coordinator._camera_ring_started
+
+        await coordinator._fetch_cameras()
+
+        assert "lastRingStart" not in coordinator.data["cameras"]["camera1"]
+        assert "camera1" not in coordinator._camera_ring_started
+
+        freezer.tick(STALE_EVENT_TIMEOUT + timedelta(seconds=1))
+        with caplog.at_level(logging.INFO):
+            coordinator._reconcile_stale_events()
+
+        assert "missed 'end' event" not in caplog.text
 
     @pytest.mark.asyncio
     async def test_async_update_data_response_error(

--- a/tests/test_coordinators.py
+++ b/tests/test_coordinators.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 import logging
 from typing import TYPE_CHECKING, Any
@@ -256,9 +257,11 @@ def _create_mock_protect_client() -> MagicMock:
         ]
     )
 
-    # WebSocket registration
-    client.register_device_update_callback = MagicMock()
-    client.register_event_update_callback = MagicMock()
+    # WebSocket support
+    client.get_host_id = AsyncMock(return_value="nvr1")
+    client.websocket = MagicMock()
+    client.websocket.subscribe_with_callback = AsyncMock()
+    client.websocket.stop = MagicMock()
 
     client.close = AsyncMock()
     return client
@@ -1184,27 +1187,122 @@ class TestUnifiProtectCoordinator:
         assert "liveviews" in coordinator.data
         assert "events" in coordinator.data
 
-    def test_websocket_callbacks_registered(self, coordinator: UnifiProtectCoordinator):
-        """Test WebSocket callbacks are registered."""
-        coordinator.protect_client.register_device_update_callback.assert_called_once()
-        coordinator.protect_client.register_event_update_callback.assert_called_once()
+    def test_websocket_state_initialized(self, coordinator: UnifiProtectCoordinator):
+        """Test WebSocket state is initialized but not started at construction."""
+        assert coordinator.websocket_task is None
+        assert coordinator._protect_websocket is coordinator.protect_client.websocket
 
-    def test_websocket_callbacks_not_registered_without_client(
+    def test_websocket_state_without_client(
         self, coordinator_no_protect: UnifiProtectCoordinator
     ):
-        """Test WebSocket callbacks not registered without protect client."""
-        # No assertions needed - just ensure no exceptions
+        """Test WebSocket state without a protect client."""
         assert coordinator_no_protect.protect_client is None
+        assert coordinator_no_protect._protect_websocket is None
+        assert coordinator_no_protect.websocket_task is None
 
-    def test_setup_websocket_callbacks_returns_early_without_client(
+    @pytest.mark.asyncio
+    async def test_async_start_websocket_without_client(
         self, coordinator_no_protect: UnifiProtectCoordinator
     ):
-        """Test _setup_websocket_callbacks returns early without client (line 99)."""
-        # Explicitly call _setup_websocket_callbacks with no protect_client
-        # This should return early and not raise any exceptions
-        coordinator_no_protect._setup_websocket_callbacks()
-        # If we get here, the return statement was executed
-        assert coordinator_no_protect.protect_client is None
+        """Test async_start_websocket returns early without a protect client."""
+        await coordinator_no_protect.async_start_websocket()
+        assert coordinator_no_protect.websocket_task is None
+
+    @pytest.mark.asyncio
+    async def test_async_start_websocket_success(
+        self, hass: HomeAssistant, coordinator: UnifiProtectCoordinator
+    ):
+        """Test async_start_websocket resolves host_id and starts a task."""
+        coordinator.protect_client.get_host_id = AsyncMock(return_value="nvr1")
+        coordinator._protect_websocket.subscribe_with_callback = AsyncMock()
+
+        await coordinator.async_start_websocket()
+
+        assert coordinator.websocket_task is not None
+        coordinator.protect_client.get_host_id.assert_awaited_once()
+        await coordinator.websocket_task
+
+        coordinator._protect_websocket.subscribe_with_callback.assert_awaited_once_with(
+            "nvr1",
+            coordinator._site_id,
+            "devices",
+            coordinator._on_websocket_message,
+            reconnect=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_async_start_websocket_already_running(
+        self, coordinator: UnifiProtectCoordinator
+    ):
+        """Test async_start_websocket is a no-op if already running."""
+        existing_task = asyncio.get_event_loop().create_future()
+        coordinator.websocket_task = existing_task  # type: ignore[assignment]
+        coordinator.protect_client.get_host_id = AsyncMock(return_value="nvr1")
+
+        await coordinator.async_start_websocket()
+
+        coordinator.protect_client.get_host_id.assert_not_called()
+        assert coordinator.websocket_task is existing_task
+        existing_task.set_result(None)
+
+    @pytest.mark.asyncio
+    async def test_async_start_websocket_host_id_failure(
+        self, coordinator: UnifiProtectCoordinator
+    ):
+        """Test async_start_websocket swallows host_id resolution failures."""
+        coordinator.protect_client.get_host_id = AsyncMock(
+            side_effect=Exception("no NVR")
+        )
+
+        # Should not raise - WebSocket is additive, polling stays the fallback.
+        await coordinator.async_start_websocket()
+
+        assert coordinator.websocket_task is None
+
+    def test_on_websocket_message_top_level(self, coordinator: UnifiProtectCoordinator):
+        """Test the WS message adapter with fields at the top level."""
+        coordinator._on_websocket_message(
+            {"modelKey": "sensor", "id": "sensor3", "isOpened": True}
+        )
+
+        assert coordinator.data["sensors"]["sensor3"]["isOpened"] is True
+
+    def test_on_websocket_message_nested_payload(
+        self, coordinator: UnifiProtectCoordinator
+    ):
+        """Test the WS message adapter with fields nested under 'payload'."""
+        coordinator._on_websocket_message(
+            {"payload": {"modelKey": "sensor", "id": "sensor4", "isOpened": False}}
+        )
+
+        assert coordinator.data["sensors"]["sensor4"]["isOpened"] is False
+
+    def test_on_websocket_message_snake_case_model_key(
+        self, coordinator: UnifiProtectCoordinator
+    ):
+        """Test the WS message adapter accepts snake_case model_key."""
+        coordinator._on_websocket_message({"model_key": "light", "id": "light3"})
+
+        assert "light3" in coordinator.data["lights"]
+
+    def test_on_websocket_message_missing_model_key(
+        self, coordinator: UnifiProtectCoordinator, caplog: pytest.LogCaptureFixture
+    ):
+        """Test the WS message adapter warns and drops unparseable messages."""
+        with caplog.at_level(logging.WARNING):
+            coordinator._on_websocket_message({"id": "sensor5"})
+
+        assert "missing modelKey" in caplog.text
+        assert "sensor5" not in coordinator.data["sensors"]
+
+    def test_on_websocket_message_not_a_dict(
+        self, coordinator: UnifiProtectCoordinator, caplog: pytest.LogCaptureFixture
+    ):
+        """Test the WS message adapter warns on non-dict payloads."""
+        with caplog.at_level(logging.WARNING):
+            coordinator._on_websocket_message("not-a-dict")  # type: ignore[arg-type]
+
+        assert "not a JSON object" in caplog.text
 
     @pytest.mark.asyncio
     async def test_async_update_data_success(
@@ -1554,25 +1652,24 @@ class TestUnifiProtectCoordinator:
             # camera2 should be marked for removal
             mock_registry.return_value.async_update_device.assert_called()
 
-    def test_websocket_callbacks_exception(
+    def test_websocket_construction_does_not_start_task(
         self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
     ):
-        """Test WebSocket callback setup handles exceptions gracefully."""
+        """Test constructing the coordinator never starts the WebSocket task.
+
+        Starting requires an await (to resolve host_id), so it must happen via
+        async_start_websocket(), not as a side effect of __init__.
+        """
         network_client = _create_mock_network_client()
         protect_client = _create_mock_protect_client()
-        # Make callback registration raise an exception
-        protect_client.register_device_update_callback = MagicMock(
-            side_effect=Exception("Callback error")
-        )
 
-        # Should not raise - coordinator should handle the exception
         coordinator = UnifiProtectCoordinator(
             hass=hass,
             network_client=network_client,
             protect_client=protect_client,
             entry=mock_config_entry,
         )
-        assert coordinator is not None
+        assert coordinator.websocket_task is None
 
     def test_handle_event_update_unknown_device(
         self, coordinator: UnifiProtectCoordinator
@@ -2693,25 +2790,12 @@ class TestProtectCoordinatorEdgeCases:
             entry=mock_config_entry,
         )
 
-    def test_setup_websocket_callbacks_no_register_device_callback(
+    def test_site_id_default(
         self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
     ):
-        """Test setup when protect_client lacks register_device_update_callback."""
+        """Test the coordinator defaults site_id to 'default' when unset."""
         network_client = _create_mock_network_client()
-        protect_client = MagicMock()
-        # Remove register_device_update_callback from spec
-        del protect_client.register_device_update_callback
-        protect_client.register_event_update_callback = MagicMock()
-        protect_client.cameras = MagicMock()
-        protect_client.cameras.get_all = AsyncMock(return_value=[])
-        protect_client.lights = MagicMock()
-        protect_client.lights.get_all = AsyncMock(return_value=[])
-        protect_client.sensors = MagicMock()
-        protect_client.sensors.get_all = AsyncMock(return_value=[])
-        protect_client.nvr = MagicMock()
-        protect_client.nvr.get = AsyncMock(return_value=MagicMock(id="nvr1"))
-        protect_client.chimes = MagicMock()
-        protect_client.chimes.get_all = AsyncMock(return_value=[])
+        protect_client = _create_mock_protect_client()
 
         coordinator = UnifiProtectCoordinator(
             hass=hass,
@@ -2720,70 +2804,24 @@ class TestProtectCoordinatorEdgeCases:
             entry=mock_config_entry,
         )
 
-        # Should not raise and event callback should still be registered
-        protect_client.register_event_update_callback.assert_called_once()
-        assert coordinator.protect_client is not None
+        assert coordinator._site_id == "default"
 
-    def test_setup_websocket_callbacks_no_register_event_callback(
+    def test_site_id_custom(
         self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
     ):
-        """Test setup when protect_client lacks register_event_update_callback."""
+        """Test the coordinator accepts a custom site_id (REMOTE routing)."""
         network_client = _create_mock_network_client()
-        protect_client = MagicMock()
-        protect_client.register_device_update_callback = MagicMock()
-        # Remove register_event_update_callback from spec
-        del protect_client.register_event_update_callback
-        protect_client.cameras = MagicMock()
-        protect_client.cameras.get_all = AsyncMock(return_value=[])
-        protect_client.lights = MagicMock()
-        protect_client.lights.get_all = AsyncMock(return_value=[])
-        protect_client.sensors = MagicMock()
-        protect_client.sensors.get_all = AsyncMock(return_value=[])
-        protect_client.nvr = MagicMock()
-        protect_client.nvr.get = AsyncMock(return_value=MagicMock(id="nvr1"))
-        protect_client.chimes = MagicMock()
-        protect_client.chimes.get_all = AsyncMock(return_value=[])
+        protect_client = _create_mock_protect_client()
 
         coordinator = UnifiProtectCoordinator(
             hass=hass,
             network_client=network_client,
             protect_client=protect_client,
             entry=mock_config_entry,
+            site_id="site2",
         )
 
-        # Should not raise and device callback should still be registered
-        protect_client.register_device_update_callback.assert_called_once()
-        assert coordinator.protect_client is not None
-
-    def test_setup_websocket_callbacks_exception(
-        self, hass: HomeAssistant, mock_config_entry: MockConfigEntry
-    ):
-        """Test setup when callback registration raises exception."""
-        network_client = _create_mock_network_client()
-        protect_client = MagicMock()
-        protect_client.register_device_update_callback = MagicMock(
-            side_effect=Exception("Registration failed")
-        )
-        protect_client.register_event_update_callback = MagicMock()
-        protect_client.cameras = MagicMock()
-        protect_client.cameras.get_all = AsyncMock(return_value=[])
-        protect_client.lights = MagicMock()
-        protect_client.lights.get_all = AsyncMock(return_value=[])
-        protect_client.sensors = MagicMock()
-        protect_client.sensors.get_all = AsyncMock(return_value=[])
-        protect_client.nvr = MagicMock()
-        protect_client.nvr.get = AsyncMock(return_value=MagicMock(id="nvr1"))
-        protect_client.chimes = MagicMock()
-        protect_client.chimes.get_all = AsyncMock(return_value=[])
-
-        # Should not raise
-        coordinator = UnifiProtectCoordinator(
-            hass=hass,
-            network_client=network_client,
-            protect_client=protect_client,
-            entry=mock_config_entry,
-        )
-        assert coordinator.protect_client is not None
+        assert coordinator._site_id == "site2"
 
     @pytest.mark.asyncio
     async def test_fetch_viewers_no_viewers_attribute(

--- a/tests/test_coordinators.py
+++ b/tests/test_coordinators.py
@@ -34,6 +34,7 @@ from custom_components.unifi_insights.coordinators.config import UnifiConfigCoor
 from custom_components.unifi_insights.coordinators.device import UnifiDeviceCoordinator
 from custom_components.unifi_insights.coordinators.facade import UnifiFacadeCoordinator
 from custom_components.unifi_insights.coordinators.protect import (
+    STALE_EVENT_TIMEOUT,
     UnifiProtectCoordinator,
 )
 
@@ -1190,6 +1191,7 @@ class TestUnifiProtectCoordinator:
     def test_websocket_state_initialized(self, coordinator: UnifiProtectCoordinator):
         """Test WebSocket state is initialized but not started at construction."""
         assert coordinator.websocket_task is None
+        assert coordinator.events_websocket_task is None
         assert coordinator._protect_websocket is coordinator.protect_client.websocket
 
     def test_websocket_state_without_client(
@@ -1199,6 +1201,7 @@ class TestUnifiProtectCoordinator:
         assert coordinator_no_protect.protect_client is None
         assert coordinator_no_protect._protect_websocket is None
         assert coordinator_no_protect.websocket_task is None
+        assert coordinator_no_protect.events_websocket_task is None
 
     @pytest.mark.asyncio
     async def test_async_start_websocket_without_client(
@@ -1212,23 +1215,38 @@ class TestUnifiProtectCoordinator:
     async def test_async_start_websocket_success(
         self, hass: HomeAssistant, coordinator: UnifiProtectCoordinator
     ):
-        """Test async_start_websocket resolves host_id and starts a task."""
+        """Test async_start_websocket resolves host_id and starts both the
+        devices and events subscriptions (see task 1: the missing events
+        subscription is the root cause of motion detection never firing).
+        """
         coordinator.protect_client.get_host_id = AsyncMock(return_value="nvr1")
         coordinator._protect_websocket.subscribe_with_callback = AsyncMock()
 
         await coordinator.async_start_websocket()
 
         assert coordinator.websocket_task is not None
+        assert coordinator.events_websocket_task is not None
         coordinator.protect_client.get_host_id.assert_awaited_once()
         await coordinator.websocket_task
+        await coordinator.events_websocket_task
 
-        coordinator._protect_websocket.subscribe_with_callback.assert_awaited_once_with(
+        coordinator._protect_websocket.subscribe_with_callback.assert_any_await(
             "nvr1",
             coordinator._site_id,
             "devices",
             coordinator._on_websocket_message,
             reconnect=True,
+            on_connection_state_change=coordinator._on_websocket_connection_state_change,
         )
+        coordinator._protect_websocket.subscribe_with_callback.assert_any_await(
+            "nvr1",
+            coordinator._site_id,
+            "events",
+            coordinator._on_websocket_event_message,
+            reconnect=True,
+            on_connection_state_change=coordinator._on_websocket_connection_state_change,
+        )
+        assert coordinator._protect_websocket.subscribe_with_callback.await_count == 2
 
     @pytest.mark.asyncio
     async def test_async_start_websocket_already_running(
@@ -1258,6 +1276,7 @@ class TestUnifiProtectCoordinator:
         await coordinator.async_start_websocket()
 
         assert coordinator.websocket_task is None
+        assert coordinator.events_websocket_task is None
 
     def test_on_websocket_message_top_level(self, coordinator: UnifiProtectCoordinator):
         """Test the WS message adapter with fields at the top level."""
@@ -1367,6 +1386,58 @@ class TestUnifiProtectCoordinator:
         assert warning_records == []
         assert any("sensor8" in r.getMessage() for r in debug_records)
 
+    def test_on_websocket_message_does_not_clobber_type_with_envelope_verb(
+        self, coordinator: UnifiProtectCoordinator
+    ):
+        """The envelope's top-level "type" (the action verb) must not
+        overwrite a real device "type" field on a partial update frame.
+
+        Regression test: `containers = [payload, action, item, message]`
+        included the raw envelope unconditionally, so its "type": "update"
+        leaked into the merged device dict whenever `item` was a partial
+        delta that didn't re-send the unchanged "type" field - clobbering
+        the previously-correct hardware model string. Measured in
+        production flipping back and forth 49 times in 10 minutes for
+        UFP-SENSE/USL-Entry-US/USL-Environmental-US sensors.
+        """
+        coordinator.data["sensors"]["sensor10"] = {
+            "id": "sensor10",
+            "modelKey": "sensor",
+            "type": "UFP-SENSE",
+            "isOpened": False,
+        }
+
+        # A partial WS update: the envelope says "update", and the item
+        # only carries the field that actually changed (isOpened) - real
+        # Protect delta frames are not guaranteed to re-send "type".
+        coordinator._on_websocket_message(
+            {
+                "type": "update",
+                "item": {"modelKey": "sensor", "id": "sensor10", "isOpened": True},
+            }
+        )
+
+        assert coordinator.data["sensors"]["sensor10"]["type"] == "UFP-SENSE"
+        assert coordinator.data["sensors"]["sensor10"]["isOpened"] is True
+
+    def test_on_websocket_message_replaces_device_dict_not_mutates_in_place(
+        self, coordinator: UnifiProtectCoordinator
+    ):
+        """A WS update must produce a new per-device dict, not mutate the
+        old one in place - in-place mutation can make HA listeners that
+        hold a stale reference miss the transition (see task 4).
+        """
+        original = {"id": "sensor11", "modelKey": "sensor", "isOpened": False}
+        coordinator.data["sensors"]["sensor11"] = original
+
+        coordinator._on_websocket_message(
+            {"modelKey": "sensor", "id": "sensor11", "isOpened": True}
+        )
+
+        assert coordinator.data["sensors"]["sensor11"] is not original
+        assert original["isOpened"] is False
+        assert coordinator.data["sensors"]["sensor11"]["isOpened"] is True
+
     @pytest.mark.asyncio
     async def test_async_stop_websocket_noop_when_never_started(
         self, coordinator: UnifiProtectCoordinator
@@ -1385,7 +1456,10 @@ class TestUnifiProtectCoordinator:
     async def test_async_stop_websocket_stops_and_awaits_real_task(
         self, coordinator: UnifiProtectCoordinator
     ):
-        """Test async_stop_websocket stops the socket and awaits a real task."""
+        """Test async_stop_websocket stops the socket and awaits BOTH real
+        tasks (devices and events - task 1 requires both to be stopped and
+        awaited, mirroring the existing devices-only teardown ordering).
+        """
         coordinator.protect_client.get_host_id = AsyncMock(return_value="nvr1")
 
         async def _run_forever(*_args, **_kwargs):
@@ -1395,14 +1469,18 @@ class TestUnifiProtectCoordinator:
             side_effect=_run_forever
         )
         await coordinator.async_start_websocket()
-        task = coordinator.websocket_task
-        assert task is not None
-        assert not task.done()
+        devices_task = coordinator.websocket_task
+        events_task = coordinator.events_websocket_task
+        assert devices_task is not None
+        assert events_task is not None
+        assert not devices_task.done()
+        assert not events_task.done()
 
         await coordinator.async_stop_websocket()
 
         coordinator._protect_websocket.stop.assert_called_once()
-        assert task.done()
+        assert devices_task.done()
+        assert events_task.done()
 
     @pytest.mark.asyncio
     async def test_async_update_data_success(
@@ -1811,6 +1889,411 @@ class TestUnifiProtectCoordinator:
         # Events should still be stored
         assert "motion" in coordinator.data["events"]
         assert "event_no_device" in coordinator.data["events"]["motion"]
+
+    def test_handle_event_update_resolves_camera_id_field(
+        self, coordinator: UnifiProtectCoordinator
+    ):
+        """Test device id resolution tolerates "cameraId" (models/event.py's
+        actual field name), not just the invented "device" key.
+
+        UNVALIDATED (task 3): the real `Event` model
+        (api/protect/models/event.py) has no generic "device" field - only
+        `camera`/`cameraId` or `sensor`/`sensorId`. Before this fix,
+        `_process_event_for_device` was unreachable dead code in practice
+        because it only ever looked for "device".
+        """
+        coordinator.data["cameras"]["camera1"] = {"id": "camera1", "name": "Test"}
+
+        coordinator._handle_event_update(
+            "motion",
+            {"id": "event20", "cameraId": "camera1", "start": 111, "end": None},
+        )
+
+        assert coordinator.data["cameras"]["camera1"]["lastMotionStart"] == 111
+
+    def test_handle_event_update_smart_detect_type_alias(
+        self, coordinator: UnifiProtectCoordinator
+    ):
+        """Test the "smartDetect" event type (models/event.py's
+        EventType.SMART_DETECT) is accepted alongside the original
+        "smartDetectZone" comparison - UNVALIDATED (task 3) which of the
+        two (or both) a real frame actually uses.
+        """
+        coordinator.data["cameras"]["camera1"] = {"id": "camera1", "name": "Test"}
+
+        coordinator._handle_event_update(
+            "smartDetect",
+            {
+                "id": "event21",
+                "device": "camera1",
+                "smartDetectTypes": ["person"],
+                "start": 111,
+                "end": None,
+            },
+        )
+
+        assert coordinator.data["cameras"]["camera1"]["lastSmartDetectTypes"] == [
+            "person"
+        ]
+
+    # -- Task 1 / 3: the "events" WebSocket subscription adapter ------------
+
+    def test_on_websocket_event_message_item_wrapper(
+        self, coordinator: UnifiProtectCoordinator
+    ):
+        """Test the events adapter with fields nested under "item", mirroring
+        the confirmed "devices" envelope shape (see _on_websocket_message).
+        """
+        coordinator.data["cameras"]["camera1"] = {"id": "camera1", "name": "Test"}
+
+        coordinator._on_websocket_event_message(
+            {
+                "type": "add",
+                "item": {
+                    "type": "motion",
+                    "id": "event30",
+                    "camera": "camera1",
+                    "start": 555,
+                    "end": None,
+                },
+            }
+        )
+
+        assert "event30" in coordinator.data["events"]["motion"]
+        assert coordinator.data["cameras"]["camera1"]["lastMotionStart"] == 555
+        assert coordinator.data["cameras"]["camera1"]["lastMotionEnd"] is None
+
+    def test_on_websocket_event_message_flat_frame(
+        self, coordinator: UnifiProtectCoordinator
+    ):
+        """Test the events adapter with no item/payload/action wrapper - a
+        flat frame's own top-level "type" is the real event type (there is
+        no separate envelope to strip it from in this shape).
+        """
+        coordinator.data["cameras"]["camera1"] = {"id": "camera1", "name": "Test"}
+
+        coordinator._on_websocket_event_message(
+            {"type": "motion", "id": "event31", "camera": "camera1", "start": 777}
+        )
+
+        assert coordinator.data["cameras"]["camera1"]["lastMotionStart"] == 777
+
+    def test_on_websocket_event_message_not_a_dict(
+        self, coordinator: UnifiProtectCoordinator, caplog: pytest.LogCaptureFixture
+    ):
+        """Test the events adapter warns and drops non-dict payloads instead
+        of raising (task 3: never raise into the WS callback).
+        """
+        with caplog.at_level(logging.WARNING):
+            coordinator._on_websocket_event_message("not-a-dict")  # type: ignore[arg-type]
+
+        assert "not a JSON object" in caplog.text
+
+    def test_on_websocket_event_message_missing_type_warns_once_then_debug(
+        self, coordinator: UnifiProtectCoordinator, caplog: pytest.LogCaptureFixture
+    ):
+        """Test an unparseable (missing event type) frame logs WARNING once,
+        then DEBUG on repeat - mirrors the devices adapter's existing cap.
+        """
+        with caplog.at_level(logging.DEBUG):
+            coordinator._on_websocket_event_message({"id": "event32"})
+            caplog.clear()
+            coordinator._on_websocket_event_message({"id": "event33"})
+
+        warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+        debug_records = [r for r in caplog.records if r.levelno == logging.DEBUG]
+        assert warning_records == []
+        assert any("event33" in r.getMessage() for r in debug_records)
+
+    def test_on_websocket_event_message_missing_id_is_dropped(
+        self, coordinator: UnifiProtectCoordinator, caplog: pytest.LogCaptureFixture
+    ):
+        """Test a resolvable type with no id logs at debug and is dropped."""
+        with caplog.at_level(logging.DEBUG):
+            coordinator._on_websocket_event_message({"type": "motion"})
+
+        assert "missing event id" in caplog.text
+        assert coordinator.data["events"] == {}
+
+    def test_on_websocket_event_message_never_raises_on_handler_error(
+        self, coordinator: UnifiProtectCoordinator, caplog: pytest.LogCaptureFixture
+    ):
+        """Test an exception from `_handle_event_update` is logged and
+        swallowed, not propagated into the WS callback (task 3: the events
+        path has never run in production, so its schema assumptions must
+        degrade safely rather than kill the reconnect loop).
+        """
+        with (
+            patch.object(
+                coordinator,
+                "_handle_event_update",
+                side_effect=RuntimeError("boom"),
+            ),
+            caplog.at_level(logging.ERROR),
+        ):
+            coordinator._on_websocket_event_message(
+                {"type": "motion", "id": "event34", "device": "camera1"}
+            )
+
+        assert "unexpected error processing" in caplog.text.lower()
+
+    # -- Task 2: bounded auto-off for the motion/smart-detect/ring latch ----
+
+    def test_motion_latch_survives_within_timeout(
+        self, coordinator: UnifiProtectCoordinator, freezer
+    ):
+        """Test reconciliation does not clear a latch that is still young."""
+        coordinator.data["cameras"]["camera1"] = {"id": "camera1", "name": "Test"}
+        coordinator._handle_event_update(
+            "motion",
+            {"id": "event40", "device": "camera1", "start": 1, "end": None},
+        )
+
+        freezer.tick(STALE_EVENT_TIMEOUT - timedelta(seconds=1))
+        coordinator._reconcile_stale_events()
+
+        assert coordinator.data["cameras"]["camera1"]["lastMotionEnd"] is None
+
+    def test_motion_latch_auto_clears_after_stale_timeout(
+        self, coordinator: UnifiProtectCoordinator, freezer
+    ):
+        """CRITICAL regression test: a dropped "end" frame must not latch
+        `camera_motion` ON forever - it must self-clear after
+        STALE_EVENT_TIMEOUT rather than trusting event pairing alone. A
+        permanently-ON motion sensor in a home security system is worse
+        than one that never fires (see coordinator module docstring).
+        """
+        coordinator.data["cameras"]["camera1"] = {"id": "camera1", "name": "Test"}
+        coordinator._handle_event_update(
+            "motion",
+            {"id": "event41", "device": "camera1", "start": 1, "end": None},
+        )
+        assert coordinator.data["cameras"]["camera1"]["lastMotionEnd"] is None
+
+        freezer.tick(STALE_EVENT_TIMEOUT + timedelta(seconds=1))
+        coordinator._reconcile_stale_events()
+
+        assert coordinator.data["cameras"]["camera1"]["lastMotionEnd"] is not None
+
+    def test_smart_detect_latch_auto_clears_and_resets_types(
+        self, coordinator: UnifiProtectCoordinator, freezer
+    ):
+        """Test a stale smart-detect latch clears lastMotionEnd AND resets
+        lastSmartDetectTypes, so person/vehicle/animal detection sensors
+        also turn back off rather than staying latched on a stale type.
+        """
+        coordinator.data["cameras"]["camera1"] = {"id": "camera1", "name": "Test"}
+        coordinator._handle_event_update(
+            "smartDetectZone",
+            {
+                "id": "event42",
+                "device": "camera1",
+                "smartDetectTypes": ["person"],
+                "start": 1,
+                "end": None,
+            },
+        )
+
+        freezer.tick(STALE_EVENT_TIMEOUT + timedelta(seconds=1))
+        coordinator._reconcile_stale_events()
+
+        assert coordinator.data["cameras"]["camera1"]["lastMotionEnd"] is not None
+        assert coordinator.data["cameras"]["camera1"]["lastSmartDetectTypes"] == []
+
+    def test_smart_detect_event_tolerates_non_list_smart_detect_types(
+        self, coordinator: UnifiProtectCoordinator
+    ):
+        """Test a non-list smartDetectTypes value (unconfirmed real shape -
+        see class docstring) degrades to an empty list instead of storing
+        garbage or raising.
+        """
+        coordinator.data["cameras"]["camera1"] = {"id": "camera1", "name": "Test"}
+
+        coordinator._handle_event_update(
+            "smartDetectZone",
+            {
+                "id": "event46",
+                "device": "camera1",
+                "smartDetectTypes": "person",  # not a list
+                "start": 1,
+                "end": 2,
+            },
+        )
+
+        assert coordinator.data["cameras"]["camera1"]["lastSmartDetectTypes"] == []
+
+    def test_light_motion_latch_auto_clears_after_stale_timeout(
+        self, coordinator: UnifiProtectCoordinator, freezer
+    ):
+        """Test the same bounded auto-off applies to light motion latches."""
+        coordinator.data["lights"]["light1"] = {"id": "light1", "name": "Test"}
+        coordinator._handle_event_update(
+            "motion",
+            {"id": "event43", "device": "light1", "start": 1, "end": None},
+        )
+
+        freezer.tick(STALE_EVENT_TIMEOUT + timedelta(seconds=1))
+        coordinator._reconcile_stale_events()
+
+        assert coordinator.data["lights"]["light1"]["lastMotionEnd"] is not None
+
+    def test_ring_latch_auto_clears_after_stale_timeout(
+        self, coordinator: UnifiProtectCoordinator, freezer
+    ):
+        """Test the doorbell ring latch is bounded the same way as motion -
+        it is exposed to the identical dropped-end-frame risk once the
+        events stream is live.
+        """
+        coordinator.data["cameras"]["camera1"] = {"id": "camera1", "name": "Test"}
+        coordinator._handle_event_update(
+            "ring",
+            {"id": "event44", "device": "camera1", "start": 1, "end": None},
+        )
+
+        freezer.tick(STALE_EVENT_TIMEOUT + timedelta(seconds=1))
+        coordinator._reconcile_stale_events()
+
+        assert coordinator.data["cameras"]["camera1"]["lastRingEnd"] is not None
+
+    def test_ring_latch_normal_end_event_clears_tracker(
+        self, coordinator: UnifiProtectCoordinator
+    ):
+        """Test a normal paired ring "end" event pops the ring tracker
+        immediately, mirroring the motion latch's normal-clear path.
+        """
+        coordinator.data["cameras"]["camera1"] = {"id": "camera1", "name": "Test"}
+        coordinator._handle_event_update(
+            "ring",
+            {"id": "event47", "device": "camera1", "start": 1, "end": None},
+        )
+        assert "camera1" in coordinator._camera_ring_started
+
+        coordinator._handle_event_update(
+            "ring",
+            {"id": "event47", "device": "camera1", "start": 1, "end": 2},
+        )
+
+        assert coordinator.data["cameras"]["camera1"]["lastRingEnd"] == 2
+        assert "camera1" not in coordinator._camera_ring_started
+
+    def test_reconcile_stale_events_skips_tracker_for_removed_device(
+        self, coordinator: UnifiProtectCoordinator, freezer
+    ):
+        """Test reconciliation for a stale tracker entry whose device has
+        since disappeared (e.g. removed by a REST poll rebuild) just drops
+        the tracker entry instead of raising or recreating the device.
+        """
+        coordinator.data["cameras"]["camera1"] = {"id": "camera1", "name": "Test"}
+        coordinator._handle_event_update(
+            "motion",
+            {"id": "event48", "device": "camera1", "start": 1, "end": None},
+        )
+        assert "camera1" in coordinator._camera_motion_started
+
+        # Simulate the camera vanishing (e.g. a REST poll rebuild that no
+        # longer includes it) before the timeout elapses.
+        del coordinator.data["cameras"]["camera1"]
+
+        freezer.tick(STALE_EVENT_TIMEOUT + timedelta(seconds=1))
+        coordinator._reconcile_stale_events()
+
+        assert "camera1" not in coordinator._camera_motion_started
+        assert "camera1" not in coordinator.data["cameras"]
+
+    def test_motion_latch_normal_end_event_clears_without_reconciliation(
+        self, coordinator: UnifiProtectCoordinator
+    ):
+        """Test a normal paired "end" event clears the latch immediately -
+        reconciliation is a safety net, not the primary clearing path.
+        """
+        coordinator.data["cameras"]["camera1"] = {"id": "camera1", "name": "Test"}
+        coordinator._handle_event_update(
+            "motion",
+            {"id": "event45", "device": "camera1", "start": 1, "end": None},
+        )
+        assert "camera1" in coordinator._camera_motion_started
+
+        coordinator._handle_event_update(
+            "motion",
+            {"id": "event45", "device": "camera1", "start": 1, "end": 2},
+        )
+
+        assert coordinator.data["cameras"]["camera1"]["lastMotionEnd"] == 2
+        assert "camera1" not in coordinator._camera_motion_started
+
+    @pytest.mark.asyncio
+    async def test_reconcile_stale_events_runs_on_periodic_poll(
+        self, coordinator: UnifiProtectCoordinator
+    ):
+        """Test the periodic REST poll also reconciles stale latches,
+        rather than relying solely on event pairing.
+        """
+        with patch.object(coordinator, "_reconcile_stale_events") as mock_reconcile:
+            await coordinator._async_update_data()
+
+        mock_reconcile.assert_called_once()
+
+    def test_reconcile_stale_events_runs_on_websocket_reconnect(
+        self, coordinator: UnifiProtectCoordinator
+    ):
+        """Test a WS (re)connect triggers reconciliation - a missed "end"
+        frame during the outage would otherwise wait for the next poll.
+        """
+        with patch.object(coordinator, "_reconcile_stale_events") as mock_reconcile:
+            coordinator._on_websocket_connection_state_change(connected=True)
+
+        mock_reconcile.assert_called_once()
+
+        with patch.object(
+            coordinator, "_reconcile_stale_events"
+        ) as mock_reconcile_disconnect:
+            coordinator._on_websocket_connection_state_change(connected=False)
+
+        mock_reconcile_disconnect.assert_not_called()
+
+    # -- Task 5: WebSocket health signal -------------------------------------
+
+    def test_websocket_health_initial_state(self, coordinator: UnifiProtectCoordinator):
+        """Test the WS health signal starts unconnected/unknown."""
+        assert coordinator._ws_connected is False
+        assert coordinator._last_ws_message is None
+        assert coordinator.websocket_health == {
+            "connected": False,
+            "last_message_at": None,
+        }
+
+    def test_websocket_health_updates_on_devices_frame(
+        self, coordinator: UnifiProtectCoordinator
+    ):
+        """Test any inbound devices frame marks the socket connected and
+        records when it was last heard from - even an unparseable one,
+        since receiving anything is evidence the wire is alive.
+        """
+        coordinator._on_websocket_message({"id": "sensor50"})
+
+        assert coordinator._ws_connected is True
+        assert coordinator._last_ws_message is not None
+        assert coordinator.websocket_health["connected"] is True
+        assert coordinator.websocket_health["last_message_at"] is not None
+
+    def test_websocket_health_updates_on_events_frame(
+        self, coordinator: UnifiProtectCoordinator
+    ):
+        """Test any inbound events frame also marks the socket connected."""
+        coordinator._on_websocket_event_message({"id": "event51"})
+
+        assert coordinator._ws_connected is True
+        assert coordinator._last_ws_message is not None
+
+    def test_websocket_health_reflects_connection_state_changes(
+        self, coordinator: UnifiProtectCoordinator
+    ):
+        """Test the connection-state callback directly drives `_ws_connected`."""
+        coordinator._on_websocket_connection_state_change(connected=True)
+        assert coordinator._ws_connected is True
+
+        coordinator._on_websocket_connection_state_change(connected=False)
+        assert coordinator._ws_connected is False
 
     def test_cleanup_stale_devices_no_match(
         self, hass: HomeAssistant, coordinator: UnifiProtectCoordinator

--- a/tests/test_coordinators.py
+++ b/tests/test_coordinators.py
@@ -1277,6 +1277,23 @@ class TestUnifiProtectCoordinator:
 
         assert coordinator.data["sensors"]["sensor4"]["isOpened"] is False
 
+    def test_on_websocket_message_item_wrapper(
+        self, coordinator: UnifiProtectCoordinator
+    ):
+        """Test the WS message adapter with fields nested under 'item'.
+
+        Confirmed live against hardware 2026-08-12: local-console update
+        frames use {"type": "update", "item": {...}}, not top-level fields.
+        """
+        coordinator._on_websocket_message(
+            {
+                "type": "update",
+                "item": {"modelKey": "sensor", "id": "sensor9", "isOpened": True},
+            }
+        )
+
+        assert coordinator.data["sensors"]["sensor9"]["isOpened"] is True
+
     def test_on_websocket_message_snake_case_model_key(
         self, coordinator: UnifiProtectCoordinator
     ):

--- a/tests/test_coordinators.py
+++ b/tests/test_coordinators.py
@@ -1304,6 +1304,89 @@ class TestUnifiProtectCoordinator:
 
         assert "not a JSON object" in caplog.text
 
+    def test_on_websocket_message_action_payload_split(
+        self, coordinator: UnifiProtectCoordinator
+    ):
+        """Test the adapter merges a header/payload-split message.
+
+        Some UniFi WebSocket surfaces split the model identity into an
+        "action" header and the changed fields into "payload" (rather than
+        a single flat object). The adapter must resolve modelKey/id and the
+        field dict independently instead of picking one container and
+        giving up, or a message shaped this way would silently drop every
+        real frame.
+        """
+        coordinator._on_websocket_message(
+            {
+                "action": {"action": "update", "modelKey": "sensor", "id": "sensor6"},
+                "payload": {"isOpened": True},
+            }
+        )
+
+        assert coordinator.data["sensors"]["sensor6"]["id"] == "sensor6"
+        assert coordinator.data["sensors"]["sensor6"]["isOpened"] is True
+
+    def test_on_websocket_message_model_key_without_id(
+        self, coordinator: UnifiProtectCoordinator, caplog: pytest.LogCaptureFixture
+    ):
+        """Test a resolvable modelKey with no id logs at debug, not silently."""
+        with caplog.at_level(logging.DEBUG):
+            coordinator._on_websocket_message({"modelKey": "sensor", "isOpened": True})
+
+        assert "missing device id" in caplog.text
+        assert coordinator.data["sensors"] == {}
+
+    def test_on_websocket_message_warning_capped_after_first(
+        self, coordinator: UnifiProtectCoordinator, caplog: pytest.LogCaptureFixture
+    ):
+        """Test repeated unparseable messages only WARNING once, then DEBUG."""
+        with caplog.at_level(logging.DEBUG):
+            coordinator._on_websocket_message({"id": "sensor7"})
+            caplog.clear()
+            coordinator._on_websocket_message({"id": "sensor8"})
+
+        warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+        debug_records = [r for r in caplog.records if r.levelno == logging.DEBUG]
+        assert warning_records == []
+        assert any("sensor8" in r.getMessage() for r in debug_records)
+
+    @pytest.mark.asyncio
+    async def test_async_stop_websocket_noop_when_never_started(
+        self, coordinator: UnifiProtectCoordinator
+    ):
+        """Test async_stop_websocket is safe when no task was ever started.
+
+        It still calls ProtectWebSocket.stop() unconditionally (harmless -
+        it just sets a flag), but must not touch websocket_task since it's
+        None.
+        """
+        await coordinator.async_stop_websocket()
+
+        assert coordinator.websocket_task is None
+
+    @pytest.mark.asyncio
+    async def test_async_stop_websocket_stops_and_awaits_real_task(
+        self, coordinator: UnifiProtectCoordinator
+    ):
+        """Test async_stop_websocket stops the socket and awaits a real task."""
+        coordinator.protect_client.get_host_id = AsyncMock(return_value="nvr1")
+
+        async def _run_forever(*_args, **_kwargs):
+            await asyncio.sleep(3600)
+
+        coordinator._protect_websocket.subscribe_with_callback = AsyncMock(
+            side_effect=_run_forever
+        )
+        await coordinator.async_start_websocket()
+        task = coordinator.websocket_task
+        assert task is not None
+        assert not task.done()
+
+        await coordinator.async_stop_websocket()
+
+        coordinator._protect_websocket.stop.assert_called_once()
+        assert task.done()
+
     @pytest.mark.asyncio
     async def test_async_update_data_success(
         self, coordinator: UnifiProtectCoordinator

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -35,3 +35,21 @@ async def test_diagnostics(
     assert "test_api_key" not in str(diagnostics)
     # The key name "api_key" will appear, but the value should be redacted
     assert diagnostics["entry"]["data"]["api_key"] == "**REDACTED**"
+
+
+async def test_diagnostics_includes_websocket_health(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    enable_custom_integrations,
+) -> None:
+    """Test diagnostics surface the Protect WebSocket health signal.
+
+    There was previously no way to tell "WS connected and delivering" from
+    "connected but silent" from "reconnect-looping" (task 5) - diagnostics
+    is the first place an operator would look to distinguish those.
+    """
+    diagnostics = await async_get_config_entry_diagnostics(hass, init_integration)
+
+    assert "websocket" in diagnostics
+    assert diagnostics["websocket"]["connected"] is False
+    assert diagnostics["websocket"]["last_message_at"] is None

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -53,3 +53,16 @@ async def test_diagnostics_includes_websocket_health(
     assert "websocket" in diagnostics
     assert diagnostics["websocket"]["connected"] is False
     assert diagnostics["websocket"]["last_message_at"] is None
+
+    # Review finding 1: a single shared connected/last_message_at pair
+    # cannot tell "both subscriptions healthy" apart from "devices healthy,
+    # events silently hung" - per-subscription detail must reach this
+    # diagnostics payload too, not just the coordinator's own property.
+    assert diagnostics["websocket"]["devices"] == {
+        "connected": False,
+        "last_message_at": None,
+    }
+    assert diagnostics["websocket"]["events"] == {
+        "connected": False,
+        "last_message_at": None,
+    }

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -151,6 +151,54 @@ async def test_unload_entry(
     assert init_integration.state == ConfigEntryState.NOT_LOADED
 
 
+async def test_setup_entry_starts_protect_websocket(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    enable_custom_integrations,
+) -> None:
+    """Test setup resolves host_id and starts the real-time WebSocket.
+
+    Regression test for the dead `hasattr(..., "register_device_update_callback")`
+    stub: the coordinator must actually invoke `get_host_id()` and hand a real
+    background task to `ProtectWebSocket.subscribe_with_callback`, not just
+    construct without error.
+    """
+    runtime_data = init_integration.runtime_data
+    protect_coordinator = runtime_data.protect_coordinator
+    assert protect_coordinator is not None
+
+    runtime_data.protect_client.get_host_id.assert_awaited_once()
+    assert protect_coordinator.websocket_task is not None
+    await protect_coordinator.websocket_task
+    protect_coordinator._protect_websocket.subscribe_with_callback.assert_awaited_once()
+
+
+async def test_unload_entry_cancels_real_websocket_task(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    enable_custom_integrations,
+) -> None:
+    """Test unload stops the ProtectWebSocket and cancels/awaits the real task.
+
+    Regression test: `websocket_task.cancel()` alone does not stop
+    `subscribe_with_callback`'s reconnect loop (it swallowed
+    `CancelledError` and slept/reconnected instead), which would leave an
+    orphaned WebSocket loop running after a config entry reload.
+    """
+    runtime_data = init_integration.runtime_data
+    protect_coordinator = runtime_data.protect_coordinator
+    assert protect_coordinator is not None
+    websocket_task = protect_coordinator.websocket_task
+    assert websocket_task is not None
+
+    assert await hass.config_entries.async_unload(init_integration.entry_id)
+    await hass.async_block_till_done()
+
+    assert init_integration.state == ConfigEntryState.NOT_LOADED
+    protect_coordinator._protect_websocket.stop.assert_called_once()
+    assert websocket_task.done()
+
+
 async def test_reload_entry(
     hass: HomeAssistant,
     init_integration: MockConfigEntry,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -161,7 +161,9 @@ async def test_setup_entry_starts_protect_websocket(
     Regression test for the dead `hasattr(..., "register_device_update_callback")`
     stub: the coordinator must actually invoke `get_host_id()` and hand a real
     background task to `ProtectWebSocket.subscribe_with_callback`, not just
-    construct without error.
+    construct without error. Also confirms the second, independent "events"
+    subscription (task 1 - without it, motion detection is permanently
+    non-functional) starts alongside "devices".
     """
     runtime_data = init_integration.runtime_data
     protect_coordinator = runtime_data.protect_coordinator
@@ -169,8 +171,12 @@ async def test_setup_entry_starts_protect_websocket(
 
     runtime_data.protect_client.get_host_id.assert_awaited_once()
     assert protect_coordinator.websocket_task is not None
+    assert protect_coordinator.events_websocket_task is not None
     await protect_coordinator.websocket_task
-    protect_coordinator._protect_websocket.subscribe_with_callback.assert_awaited_once()
+    await protect_coordinator.events_websocket_task
+    assert (
+        protect_coordinator._protect_websocket.subscribe_with_callback.await_count == 2
+    )
 
 
 async def test_unload_entry_cancels_real_websocket_task(
@@ -189,7 +195,9 @@ async def test_unload_entry_cancels_real_websocket_task(
     protect_coordinator = runtime_data.protect_coordinator
     assert protect_coordinator is not None
     websocket_task = protect_coordinator.websocket_task
+    events_websocket_task = protect_coordinator.events_websocket_task
     assert websocket_task is not None
+    assert events_websocket_task is not None
 
     assert await hass.config_entries.async_unload(init_integration.entry_id)
     await hass.async_block_till_done()
@@ -203,6 +211,7 @@ async def test_unload_entry_cancels_real_websocket_task(
     # async_stop_websocket() is idempotent, so this is expected, not a bug.
     assert protect_coordinator._protect_websocket.stop.call_count == 2
     assert websocket_task.done()
+    assert events_websocket_task.done()
 
 
 async def test_reload_entry(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -195,7 +195,13 @@ async def test_unload_entry_cancels_real_websocket_task(
     await hass.async_block_till_done()
 
     assert init_integration.state == ConfigEntryState.NOT_LOADED
-    protect_coordinator._protect_websocket.stop.assert_called_once()
+    # Called twice by design: once from async_unload_entry's explicit call
+    # (correct ordering - stop before closing the Protect client) and once
+    # more via the entry.async_on_unload safety net registered in
+    # async_setup_entry (covers a setup failure that happens after the
+    # WebSocket starts but before async_unload_entry ever runs).
+    # async_stop_websocket() is idempotent, so this is expected, not a bug.
+    assert protect_coordinator._protect_websocket.stop.call_count == 2
     assert websocket_task.done()
 
 

--- a/tests/test_protect_websocket.py
+++ b/tests/test_protect_websocket.py
@@ -37,6 +37,37 @@ def _remote_client() -> UniFiProtectClient:
     )
 
 
+@pytest.mark.asyncio
+async def test_connect_passes_heartbeat_to_ws_connect() -> None:
+    """`_connect()` must pass `heartbeat=30` to `session.ws_connect()`.
+
+    Regression test (review finding 1, Major): without a heartbeat, aiohttp
+    never pings a half-open connection - if the NVR stops responding
+    without ever sending a close/error frame, `async for msg in ws` in
+    `subscribe_with_callback` blocks forever and the existing
+    reconnect/backoff logic below it never gets a chance to run (an events
+    subscription stuck like this while the devices subscription reconnects
+    cleanly is exactly the "motion silently stopped working for days"
+    scenario `websocket_health` exists to catch). `heartbeat=30` makes
+    aiohttp ping every 30s and force-close the connection (surfacing as
+    `WSMsgType.CLOSED`/`ERROR`, which `subscribe_with_callback` already
+    handles) if no pong comes back, turning a silent hang into a
+    bounded-time reconnect.
+    """
+    client = _local_client()
+    ws_socket = ProtectWebSocket(client)
+
+    mock_session = MagicMock()
+    mock_session.ws_connect = AsyncMock()
+    client._ensure_session = AsyncMock(return_value=mock_session)
+
+    await ws_socket._connect("/proxy/protect/integration/v1/subscribe/devices")
+
+    mock_session.ws_connect.assert_awaited_once()
+    _args, kwargs = mock_session.ws_connect.call_args
+    assert kwargs.get("heartbeat") == 30
+
+
 def test_subscribe_path_local_uses_integration_api() -> None:
     """LOCAL WS subscribe path must match the client's own REST convention.
 

--- a/tests/test_protect_websocket.py
+++ b/tests/test_protect_websocket.py
@@ -1,0 +1,210 @@
+"""Tests for the vendored UniFi Protect WebSocket client.
+
+This module lives under `custom_components/unifi_insights/api/**`, which is
+excluded from the coverage gate (see `[tool.coverage.run].omit` in
+pyproject.toml) because it is a vendored package. It still runs live against
+production door-lock sensors, so it is tested directly here regardless of the
+gate.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import aiohttp
+import pytest
+
+from custom_components.unifi_insights.api import ApiKeyAuth, ConnectionType, LocalAuth
+from custom_components.unifi_insights.api.protect import UniFiProtectClient
+from custom_components.unifi_insights.api.protect.websocket import ProtectWebSocket
+
+
+def _local_client() -> UniFiProtectClient:
+    return UniFiProtectClient(
+        auth=LocalAuth(api_key="test-key", verify_ssl=False),
+        base_url="https://192.168.1.1",
+        connection_type=ConnectionType.LOCAL,
+    )
+
+
+def _remote_client() -> UniFiProtectClient:
+    return UniFiProtectClient(
+        auth=ApiKeyAuth(api_key="test-key"),
+        connection_type=ConnectionType.REMOTE,
+        console_id="console-1",
+    )
+
+
+def test_subscribe_path_local_uses_integration_api() -> None:
+    """LOCAL WS subscribe path must match the client's own REST convention.
+
+    Regression test: the WS path used to be hardcoded to a cloud-only
+    `/ea/hosts/{host_id}/sites/{site_id}/subscribe/...` scheme that does not
+    exist on a local console, which made the WebSocket silently non-functional
+    for LOCAL (including Protect-only) consoles.
+    """
+    client = _local_client()
+
+    assert (
+        client.websocket._subscribe_path("devices")
+        == "/proxy/protect/integration/v1/subscribe/devices"
+    )
+    assert (
+        client.websocket._subscribe_path("events")
+        == "/proxy/protect/integration/v1/subscribe/events"
+    )
+
+
+def test_subscribe_path_remote_uses_connector_routing() -> None:
+    """REMOTE WS subscribe path must route through the connector like REST calls."""
+    client = _remote_client()
+
+    assert client.websocket._subscribe_path("devices") == (
+        "/v1/connector/consoles/console-1/protect/integration/v1/subscribe/devices"
+    )
+
+
+def _make_ws(messages: list[aiohttp.WSMessage]) -> MagicMock:
+    """Build a fake aiohttp WebSocket that yields the given messages then ends."""
+    ws = MagicMock()
+    ws.closed = False
+
+    async def _aiter():
+        for msg in messages:
+            yield msg
+
+    ws.__aiter__ = lambda self=ws: _aiter()
+    ws.close = AsyncMock(side_effect=lambda: setattr(ws, "closed", True))
+    return ws
+
+
+@pytest.mark.asyncio
+async def test_subscribe_with_callback_dispatches_messages() -> None:
+    """A single successful connection delivers decoded JSON messages."""
+    client = _local_client()
+    ws_socket = ProtectWebSocket(client)
+
+    text_msg = MagicMock(type=aiohttp.WSMsgType.TEXT, data='{"modelKey": "sensor"}')
+    close_msg = MagicMock(type=aiohttp.WSMsgType.CLOSED)
+    fake_ws = _make_ws([text_msg, close_msg])
+
+    ws_socket._connect = AsyncMock(return_value=fake_ws)
+    received: list[dict] = []
+
+    await ws_socket.subscribe_with_callback(
+        "nvr1", "default", "devices", received.append, reconnect=False
+    )
+
+    assert received == [{"modelKey": "sensor"}]
+    fake_ws.close.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_subscribe_with_callback_invalid_subscription_type() -> None:
+    """Only 'devices'/'events' are valid subscription types."""
+    client = _local_client()
+    ws_socket = ProtectWebSocket(client)
+
+    with pytest.raises(ValueError, match=r"devices.*events"):
+        await ws_socket.subscribe_with_callback(
+            "nvr1", "default", "bogus", lambda _msg: None
+        )
+
+
+@pytest.mark.asyncio
+async def test_subscribe_with_callback_drops_invalid_json(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Non-JSON text frames are dropped without invoking the callback."""
+    client = _local_client()
+    ws_socket = ProtectWebSocket(client)
+
+    bad_msg = MagicMock(type=aiohttp.WSMsgType.TEXT, data="not-json")
+    close_msg = MagicMock(type=aiohttp.WSMsgType.CLOSED)
+    fake_ws = _make_ws([bad_msg, close_msg])
+    ws_socket._connect = AsyncMock(return_value=fake_ws)
+
+    callback = MagicMock()
+    with caplog.at_level(logging.DEBUG):
+        await ws_socket.subscribe_with_callback(
+            "nvr1", "default", "devices", callback, reconnect=False
+        )
+
+    callback.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_subscribe_with_callback_reconnects_after_client_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A connection error is logged at WARNING and triggers a reconnect."""
+    client = _local_client()
+    ws_socket = ProtectWebSocket(client)
+
+    close_msg = MagicMock(type=aiohttp.WSMsgType.CLOSED)
+    good_ws = _make_ws([close_msg])
+
+    connect_calls = 0
+
+    async def _connect(_path: str):
+        nonlocal connect_calls
+        connect_calls += 1
+        if connect_calls == 1:
+            msg = "handshake failed"
+            raise aiohttp.ClientConnectionError(msg)
+        # Second attempt succeeds, then subscribe_with_callback stops because
+        # reconnect=False keeps _running True only for one more loop; force
+        # stop from within the second connection.
+        ws_socket.stop()
+        return good_ws
+
+    ws_socket._connect = _connect
+
+    with caplog.at_level(logging.WARNING):
+        await ws_socket.subscribe_with_callback(
+            "nvr1",
+            "default",
+            "devices",
+            lambda _msg: None,
+            reconnect=True,
+            reconnect_delay=0,
+        )
+
+    assert connect_calls == 2
+    assert "connection error" in caplog.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_subscribe_with_callback_propagates_cancellation() -> None:
+    """Cancellation must propagate, not be swallowed into a reconnect loop.
+
+    Regression test: the previous implementation caught
+    `asyncio.CancelledError` alongside `aiohttp.ClientError` and fell through
+    to the reconnect-sleep branch, so `task.cancel()` from the integration's
+    unload path never actually stopped the background WebSocket loop.
+    """
+    client = _local_client()
+    ws_socket = ProtectWebSocket(client)
+
+    async def _connect(_path: str):
+        raise asyncio.CancelledError
+
+    ws_socket._connect = _connect
+
+    with pytest.raises(asyncio.CancelledError):
+        await ws_socket.subscribe_with_callback(
+            "nvr1", "default", "devices", lambda _msg: None
+        )
+
+
+def test_stop_sets_running_false() -> None:
+    """stop() flips the running flag so the reconnect loop exits."""
+    client = _local_client()
+    ws_socket = ProtectWebSocket(client)
+    ws_socket._running = True
+
+    ws_socket.stop()
+
+    assert ws_socket._running is False

--- a/tests/test_protect_websocket.py
+++ b/tests/test_protect_websocket.py
@@ -208,3 +208,87 @@ def test_stop_sets_running_false() -> None:
     ws_socket.stop()
 
     assert ws_socket._running is False
+
+
+@pytest.mark.asyncio
+async def test_subscribe_with_callback_reports_connect_then_disconnect() -> None:
+    """`on_connection_state_change` fires True after connect, False on exit.
+
+    The coordinator's WS health signal and its "reconcile on WS reconnect"
+    safety net (see coordinators/protect.py) both depend on knowing exactly
+    when a subscription connects/disconnects - this method is the only place
+    that actually knows.
+    """
+    client = _local_client()
+    ws_socket = ProtectWebSocket(client)
+
+    close_msg = MagicMock(type=aiohttp.WSMsgType.CLOSED)
+    fake_ws = _make_ws([close_msg])
+    ws_socket._connect = AsyncMock(return_value=fake_ws)
+
+    states: list[bool] = []
+
+    await ws_socket.subscribe_with_callback(
+        "nvr1",
+        "default",
+        "devices",
+        lambda _msg: None,
+        reconnect=False,
+        on_connection_state_change=states.append,
+    )
+
+    assert states == [True, False]
+
+
+@pytest.mark.asyncio
+async def test_subscribe_with_callback_reports_disconnect_before_reconnect() -> None:
+    """A connection error reports False (never connected) before the retry,
+    then True/False again around the successful reconnection.
+    """
+    client = _local_client()
+    ws_socket = ProtectWebSocket(client)
+
+    close_msg = MagicMock(type=aiohttp.WSMsgType.CLOSED)
+    good_ws = _make_ws([close_msg])
+
+    connect_calls = 0
+
+    async def _connect(_path: str):
+        nonlocal connect_calls
+        connect_calls += 1
+        if connect_calls == 1:
+            msg = "handshake failed"
+            raise aiohttp.ClientConnectionError(msg)
+        ws_socket.stop()
+        return good_ws
+
+    ws_socket._connect = _connect
+    states: list[bool] = []
+
+    await ws_socket.subscribe_with_callback(
+        "nvr1",
+        "default",
+        "devices",
+        lambda _msg: None,
+        reconnect=True,
+        reconnect_delay=0,
+        on_connection_state_change=states.append,
+    )
+
+    assert states == [False, True, False]
+
+
+@pytest.mark.asyncio
+async def test_subscribe_with_callback_without_state_callback_still_works() -> None:
+    """`on_connection_state_change` is optional and defaults to a no-op."""
+    client = _local_client()
+    ws_socket = ProtectWebSocket(client)
+
+    close_msg = MagicMock(type=aiohttp.WSMsgType.CLOSED)
+    fake_ws = _make_ws([close_msg])
+    ws_socket._connect = AsyncMock(return_value=fake_ws)
+
+    # Must not raise even though no callback was supplied.
+    await ws_socket.subscribe_with_callback(
+        "nvr1", "default", "devices", lambda _msg: None, reconnect=False
+    )

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -1,0 +1,60 @@
+"""Tests for translation key completeness.
+
+`translations/en.json` is the file Home Assistant actually loads at
+runtime for a custom integration; `strings.json` is the source of truth
+maintainers edit. These two files had drifted apart for the Protect
+binary_sensor entities specifically - see
+`test_binary_sensor_camera_and_sensor_translation_keys_present_in_en_json`.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from custom_components.unifi_insights.binary_sensor import BINARY_SENSOR_TYPES
+
+_INTEGRATION_DIR = Path(__file__).parent.parent / "custom_components" / "unifi_insights"
+_EN_JSON = _INTEGRATION_DIR / "translations" / "en.json"
+_STRINGS_JSON = _INTEGRATION_DIR / "strings.json"
+
+
+def test_binary_sensor_camera_and_sensor_translation_keys_present_in_en_json() -> None:
+    """Every camera_*/sensor_* binary_sensor translation_key must resolve
+    in translations/en.json, matching strings.json.
+
+    Regression test: translations/en.json's entity.binary_sensor section
+    had only 6 keys (device_status, door, doorbell, is_dark, is_recording,
+    motion) while strings.json correctly defined camera_motion,
+    camera_person_detection, etc. HA falls back to the device_class name
+    ("Motion") when a translation_key lookup fails, so all four per-camera
+    detection sensors rendered as "Motion" and collided into _2/_3/_4
+    entity_id suffixes.
+    """
+    en_data = json.loads(_EN_JSON.read_text())
+    en_keys = set(en_data["entity"]["binary_sensor"].keys())
+
+    camera_and_sensor_keys = {
+        description.translation_key
+        for description in BINARY_SENSOR_TYPES
+        if description.translation_key
+        and description.translation_key.startswith(("camera_", "sensor_"))
+    }
+
+    missing = camera_and_sensor_keys - en_keys
+    assert missing == set()
+
+
+def test_en_json_camera_and_sensor_names_match_strings_json() -> None:
+    """The values added to en.json must mirror strings.json exactly, not
+    just exist as keys - a mismatched display name would be its own bug.
+    """
+    en_data = json.loads(_EN_JSON.read_text())
+    strings_data = json.loads(_STRINGS_JSON.read_text())
+    en_binary_sensor = en_data["entity"]["binary_sensor"]
+    strings_binary_sensor = strings_data["entity"]["binary_sensor"]
+
+    for key, value in strings_binary_sensor.items():
+        if key.startswith(("camera_", "sensor_")):
+            assert key in en_binary_sensor, f"{key} missing from translations/en.json"
+            assert en_binary_sensor[key] == value


### PR DESCRIPTION
Builds on #100. The first three commits here are that PR's; only the last two are new. Happy to rebase once #100 lands.

`async_start_websocket` subscribes to the "devices" stream only. `_handle_event_update` and `_process_event_for_device` are the sole writers of `lastMotionStart`, `lastMotionEnd` and `lastSmartDetectTypes`, which the `camera_motion` and `camera_*_detection` binary sensors read, and nothing calls them. Every one of those sensors is permanently `off`, on any console. I pulled the full state history for my 12 cameras: not one motion entity had ever gone `on` since the integration was installed.

This subscribes to "events" alongside "devices", as a second task on the same `ProtectWebSocket` instance with the same start and stop ordering as the existing one.

### Guardrails

That code path had never run against real Protect traffic, so it gets a few:

- A bounded auto-off (`STALE_EVENT_TIMEOUT`, 5 minutes) on the motion, smart-detect and ring latch, reconciled on every REST poll and every reconnect rather than only on a paired "end" frame. Protect gives no delivery guarantee on "end", and latching a security sensor `on` forever the first time one drops is worse than clearing late.
- The events adapter and both handlers resolve device id and type tolerantly across the field names the `Event` model actually uses, accept both `smartDetectZone` and `smartDetect`, and never raise into the WS callback. Unparseable frames log one WARNING, then DEBUG.
- WebSocket health tracked per subscription, exposed in diagnostics as `websocket_health["devices"]` and `["events"]` with a conservative AND rollup at the top level. The old `connected`/`last_message_at` keys are kept. These were single shared fields in my first version, which would have let a chatty devices stream mask a hung events stream and report `connected: true` while motion was silently dead — exactly the failure the signal exists to catch.
- `heartbeat=30` on `ws_connect()`, so a half-open connection (NVR stops responding, no close or error frame) gets pinged and force-closed instead of blocking `async for msg in ws` forever and never reaching the reconnect backoff.

### Two bugs found along the way

The "devices" envelope's top-level `type`, which is the action verb, was clobbering a device's hardware-model `type` field on partial update frames. The merge now builds a new dict instead of leaking envelope-only keys into the device.

`_fetch_cameras()` replaces `self.data["cameras"]` wholesale from REST models that never carry the `lastMotion*`/`lastRing*` fields, which cleared an in-progress latch without popping the tracker entry. About five minutes later the reconciler would find the orphaned tracker and log a false "missed 'end' event?" for a detection the same poll had already cleared correctly. It now pops trackers whose backing start field has vanished.

### Naming

Adds the `camera_*` and `sensor_*` binary_sensor keys to `translations/en.json`. `strings.json` already had them, and the gap gave newly discovered entities colliding names (Motion, Motion 2, Motion 3, Motion 4).

### Verification

Deployed to a UNVR-PRO. Three real motion events came through within six minutes across two cameras, against a baseline of zero in the integration's entire history on that install. Smart-detect (person) has not fired yet, so plain motion is what I can vouch for so far.
