### PR TITLE
fix(coordinators): tolerate a non-JSON sites response on Protect-only consoles

### DIFF
--- a/custom_components/unifi_insights/coordinators/config.py
+++ b/custom_components/unifi_insights/coordinators/config.py
@@ -221,13 +221,11 @@ class UnifiConfigCoordinator(UnifiBaseCoordinator):
                 # hardware rather than a transient fault, and setup validation
                 # in __init__.py already tolerates it. Left unhandled, the
                 # first refresh raises UpdateFailed, then ConfigEntryNotReady,
-                # and the entry never loads. A genuine >=400 must still fail.
+                # and the entry never loads. Only a 200 is tolerated, so a
+                # redirect or any other sub-400 status still fails.
                 # UniFiNotFoundError subclasses UniFiResponseError, so this
                 # clause has to stay below the tuple above.
-                if (
-                    self.protect_client is None
-                    or err.status_code >= HTTPStatus.BAD_REQUEST
-                ):
+                if self.protect_client is None or err.status_code != HTTPStatus.OK:
                     raise
                 _LOGGER.debug(
                     "Config coordinator: sites endpoint returned a non-JSON "

--- a/custom_components/unifi_insights/coordinators/config.py
+++ b/custom_components/unifi_insights/coordinators/config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from http import HTTPStatus
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -212,6 +213,27 @@ class UnifiConfigCoordinator(UnifiBaseCoordinator):
                     )
                 else:
                     raise
+            except UniFiResponseError as err:
+                # A console with no Network application answers this endpoint
+                # with 200 and an HTML body. api/base.py raises for a 2xx
+                # non-JSON response rather than returning None, which is right
+                # in general, but here it is a permanent property of the
+                # hardware rather than a transient fault, and setup validation
+                # in __init__.py already tolerates it. Left unhandled, the
+                # first refresh raises UpdateFailed, then ConfigEntryNotReady,
+                # and the entry never loads. A genuine >=400 must still fail.
+                # UniFiNotFoundError subclasses UniFiResponseError, so this
+                # clause has to stay below the tuple above.
+                if (
+                    self.protect_client is None
+                    or err.status_code >= HTTPStatus.BAD_REQUEST
+                ):
+                    raise
+                _LOGGER.debug(
+                    "Config coordinator: sites endpoint returned a non-JSON "
+                    "body (status %s) - console has no Network application",
+                    err.status_code,
+                )
 
             sites = [self._model_to_dict(s) for s in sites_models]
             self.data["sites"] = {

--- a/custom_components/unifi_insights/coordinators/protect.py
+++ b/custom_components/unifi_insights/coordinators/protect.py
@@ -176,7 +176,7 @@ class UnifiProtectCoordinator(UnifiBaseCoordinator):
         # different failure classes.
         self._ws_parse_warned = False
         self._ws_event_parse_warned = False
-        self._ws_event_error_warned = False
+        self._ws_event_error_warned: bool = False
 
         # WebSocket health signal (task 5, hardened by review finding 1):
         # there was previously no way to tell "connected and delivering"
@@ -687,9 +687,11 @@ class UnifiProtectCoordinator(UnifiBaseCoordinator):
         # to the unparseable path spends the one-time WARNING that exists to
         # surface a genuinely wrong frame shape, leaving a real problem to be
         # logged at DEBUG afterwards. Reported on its own warned-once flag.
-        error = _pick_field(containers, "error")
+        error: Any = _pick_field(containers, "error")
         if error:
-            level = logging.DEBUG if self._ws_event_error_warned else logging.WARNING
+            level: int = (
+                logging.DEBUG if self._ws_event_error_warned else logging.WARNING
+            )
             _LOGGER.log(
                 level,
                 "Protect coordinator: events stream reported an error: %s",

--- a/custom_components/unifi_insights/coordinators/protect.py
+++ b/custom_components/unifi_insights/coordinators/protect.py
@@ -176,6 +176,7 @@ class UnifiProtectCoordinator(UnifiBaseCoordinator):
         # different failure classes.
         self._ws_parse_warned = False
         self._ws_event_parse_warned = False
+        self._ws_event_error_warned = False
 
         # WebSocket health signal (task 5, hardened by review finding 1):
         # there was previously no way to tell "connected and delivering"
@@ -679,6 +680,23 @@ class UnifiProtectCoordinator(UnifiBaseCoordinator):
         containers = [c for c in (payload, item, action) if isinstance(c, dict)]
         if not containers:
             containers = [message]
+
+        # The console reports its own faults on this stream as a frame with
+        # an "error" field and no event fields, a rate-limit notice being the
+        # common one. That is not a parse failure, and letting it fall through
+        # to the unparseable path spends the one-time WARNING that exists to
+        # surface a genuinely wrong frame shape, leaving a real problem to be
+        # logged at DEBUG afterwards. Reported on its own warned-once flag.
+        error = _pick_field(containers, "error")
+        if error:
+            level = logging.DEBUG if self._ws_event_error_warned else logging.WARNING
+            _LOGGER.log(
+                level,
+                "Protect coordinator: events stream reported an error: %s",
+                message,
+            )
+            self._ws_event_error_warned = True
+            return
 
         event_type = _pick_field(containers, "type", "eventType", "event_type")
         if not event_type:

--- a/tests/test_coordinators.py
+++ b/tests/test_coordinators.py
@@ -570,6 +570,18 @@ class TestUnifiConfigCoordinator:
             await coordinator._async_update_data()
 
     @pytest.mark.asyncio
+    async def test_async_update_data_redirect_sites_still_fails(
+        self, coordinator: UnifiConfigCoordinator
+    ):
+        """Test only a 200 is tolerated, so a 3xx is not swallowed."""
+        coordinator.network_client.sites.get_all = AsyncMock(
+            side_effect=UniFiResponseError("Redirected", status_code=302)
+        )
+
+        with pytest.raises(UpdateFailed):
+            await coordinator._async_update_data()
+
+    @pytest.mark.asyncio
     async def test_async_update_data_server_error_sites_still_fails(
         self, coordinator: UnifiConfigCoordinator
     ):

--- a/tests/test_coordinators.py
+++ b/tests/test_coordinators.py
@@ -538,6 +538,50 @@ class TestUnifiConfigCoordinator:
         assert coordinator._available is True
 
     @pytest.mark.asyncio
+    async def test_async_update_data_protect_only_console_non_json_sites(
+        self, coordinator: UnifiConfigCoordinator
+    ):
+        """Test fetch succeeds when the sites endpoint returns 200 and no JSON."""
+        coordinator.network_client.sites.get_all = AsyncMock(
+            side_effect=UniFiResponseError(
+                "API returned non-JSON response (status 200)", status_code=200
+            )
+        )
+
+        result = await coordinator._async_update_data()
+        assert result["sites"] == {}
+        assert result["wifi"] == {}
+        assert result["firewall_rules"] == {}
+        assert coordinator._available is True
+
+    @pytest.mark.asyncio
+    async def test_async_update_data_non_json_sites_without_protect(
+        self, coordinator: UnifiConfigCoordinator
+    ):
+        """Test a non-JSON sites response still fails when Protect is absent."""
+        coordinator.protect_client = None
+        coordinator.network_client.sites.get_all = AsyncMock(
+            side_effect=UniFiResponseError(
+                "API returned non-JSON response (status 200)", status_code=200
+            )
+        )
+
+        with pytest.raises(UpdateFailed):
+            await coordinator._async_update_data()
+
+    @pytest.mark.asyncio
+    async def test_async_update_data_server_error_sites_still_fails(
+        self, coordinator: UnifiConfigCoordinator
+    ):
+        """Test a >=400 response is not swallowed by the non-JSON tolerance."""
+        coordinator.network_client.sites.get_all = AsyncMock(
+            side_effect=UniFiResponseError("Server error", status_code=500)
+        )
+
+        with pytest.raises(UpdateFailed):
+            await coordinator._async_update_data()
+
+    @pytest.mark.asyncio
     async def test_async_update_data_connection_error(
         self, coordinator: UnifiConfigCoordinator
     ):

--- a/tests/test_coordinators.py
+++ b/tests/test_coordinators.py
@@ -2054,6 +2054,57 @@ class TestUnifiProtectCoordinator:
         assert warning_records == []
         assert any("event33" in r.getMessage() for r in debug_records)
 
+    def test_on_websocket_event_message_error_frame_warns_once_then_debug(
+        self, coordinator: UnifiProtectCoordinator, caplog: pytest.LogCaptureFixture
+    ):
+        """Test a console error frame is reported as an error, not as a
+        parse failure, and is capped the same warn-once way.
+        """
+        frame = {
+            "error": "Too many requests",
+            "name": "TOO_MANY_REQUESTS_ERROR",
+            "windowMs": 1000,
+            "limit": 10,
+        }
+
+        with caplog.at_level(logging.DEBUG):
+            coordinator._on_websocket_event_message(dict(frame))
+            first = [r for r in caplog.records if r.levelno == logging.WARNING]
+            assert any("reported an error" in r.getMessage() for r in first)
+            assert not any("missing event type" in r.getMessage() for r in first)
+            caplog.clear()
+            coordinator._on_websocket_event_message(dict(frame))
+
+        assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
+        assert any(
+            "reported an error" in r.getMessage()
+            for r in caplog.records
+            if r.levelno == logging.DEBUG
+        )
+
+    def test_on_websocket_event_message_error_frame_keeps_parse_warning(
+        self, coordinator: UnifiProtectCoordinator, caplog: pytest.LogCaptureFixture
+    ):
+        """Test an error frame does not spend the unparseable-frame warning.
+
+        The two share a stream but not a cause, so a genuinely malformed
+        frame must still reach WARNING after an error frame has arrived.
+        """
+        with caplog.at_level(logging.DEBUG):
+            coordinator._on_websocket_event_message(
+                {
+                    "error": "Too many requests",
+                    "name": "TOO_MANY_REQUESTS_ERROR",
+                    "windowMs": 1000,
+                    "limit": 10,
+                }
+            )
+            caplog.clear()
+            coordinator._on_websocket_event_message({"id": "event41"})
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("missing event type" in r.getMessage() for r in warnings)
+
     def test_on_websocket_event_message_missing_id_is_dropped(
         self, coordinator: UnifiProtectCoordinator, caplog: pytest.LogCaptureFixture
     ):

--- a/tests/test_coordinators.py
+++ b/tests/test_coordinators.py
@@ -540,7 +540,7 @@ class TestUnifiConfigCoordinator:
     @pytest.mark.asyncio
     async def test_async_update_data_protect_only_console_non_json_sites(
         self, coordinator: UnifiConfigCoordinator
-    ):
+    ) -> None:
         """Test fetch succeeds when the sites endpoint returns 200 and no JSON."""
         coordinator.network_client.sites.get_all = AsyncMock(
             side_effect=UniFiResponseError(
@@ -557,7 +557,7 @@ class TestUnifiConfigCoordinator:
     @pytest.mark.asyncio
     async def test_async_update_data_non_json_sites_without_protect(
         self, coordinator: UnifiConfigCoordinator
-    ):
+    ) -> None:
         """Test a non-JSON sites response still fails when Protect is absent."""
         coordinator.protect_client = None
         coordinator.network_client.sites.get_all = AsyncMock(
@@ -572,7 +572,7 @@ class TestUnifiConfigCoordinator:
     @pytest.mark.asyncio
     async def test_async_update_data_redirect_sites_still_fails(
         self, coordinator: UnifiConfigCoordinator
-    ):
+    ) -> None:
         """Test only a 200 is tolerated, so a 3xx is not swallowed."""
         coordinator.network_client.sites.get_all = AsyncMock(
             side_effect=UniFiResponseError("Redirected", status_code=302)
@@ -584,7 +584,7 @@ class TestUnifiConfigCoordinator:
     @pytest.mark.asyncio
     async def test_async_update_data_server_error_sites_still_fails(
         self, coordinator: UnifiConfigCoordinator
-    ):
+    ) -> None:
         """Test a >=400 response is not swallowed by the non-JSON tolerance."""
         coordinator.network_client.sites.get_all = AsyncMock(
             side_effect=UniFiResponseError("Server error", status_code=500)
@@ -2068,11 +2068,11 @@ class TestUnifiProtectCoordinator:
 
     def test_on_websocket_event_message_error_frame_warns_once_then_debug(
         self, coordinator: UnifiProtectCoordinator, caplog: pytest.LogCaptureFixture
-    ):
+    ) -> None:
         """Test a console error frame is reported as an error, not as a
         parse failure, and is capped the same warn-once way.
         """
-        frame = {
+        frame: dict[str, Any] = {
             "error": "Too many requests",
             "name": "TOO_MANY_REQUESTS_ERROR",
             "windowMs": 1000,
@@ -2081,7 +2081,9 @@ class TestUnifiProtectCoordinator:
 
         with caplog.at_level(logging.DEBUG):
             coordinator._on_websocket_event_message(dict(frame))
-            first = [r for r in caplog.records if r.levelno == logging.WARNING]
+            first: list[logging.LogRecord] = [
+                r for r in caplog.records if r.levelno == logging.WARNING
+            ]
             assert any("reported an error" in r.getMessage() for r in first)
             assert not any("missing event type" in r.getMessage() for r in first)
             caplog.clear()
@@ -2096,7 +2098,7 @@ class TestUnifiProtectCoordinator:
 
     def test_on_websocket_event_message_error_frame_keeps_parse_warning(
         self, coordinator: UnifiProtectCoordinator, caplog: pytest.LogCaptureFixture
-    ):
+    ) -> None:
         """Test an error frame does not spend the unparseable-frame warning.
 
         The two share a stream but not a cause, so a genuinely malformed
@@ -2114,7 +2116,9 @@ class TestUnifiProtectCoordinator:
             caplog.clear()
             coordinator._on_websocket_event_message({"id": "event41"})
 
-        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        warnings: list[logging.LogRecord] = [
+            r for r in caplog.records if r.levelno == logging.WARNING
+        ]
         assert any("missing event type" in r.getMessage() for r in warnings)
 
     def test_on_websocket_event_message_missing_id_is_dropped(


### PR DESCRIPTION
v2026.8.3 does not finish setup on my UNVR-PRO. The Protect entry sits in `setup_retry` with:

```
API error: UniFiResponseError(status=200)
```

## What happens

A console with no Network application answers `/proxy/network/integration/v1/sites` with HTTP 200 and an HTML login page. Since #97, `api/base.py` raises `UniFiResponseError` for a 2xx response whose body is not JSON instead of returning `None`, so that HTML now arrives as an exception.

`UnifiConfigCoordinator._async_update_data` guards the sites call for `UniFiNotFoundError` and `UniFiAuthenticationError`. `UniFiResponseError` is not in that tuple, so it escapes to the outer handler, becomes `UpdateFailed`, then `ConfigEntryNotReady`, and the entry never loads.

From the failing setup:

```
File "custom_components/unifi_insights/coordinators/config.py", line 205, in _async_update_data
    sites_models = await self.network_client.sites.get_all()
File "custom_components/unifi_insights/api/network/endpoints/sites.py", line 59, in get_all
File "custom_components/unifi_insights/api/base.py", line 308, in _handle_response
    raise UniFiResponseError(...)
custom_components.unifi_insights.api.exceptions.UniFiResponseError: UniFiResponseError(status=200)
```

logged just after:

```
Response is not JSON: <!doctype html><html lang="en">...
```

#97 was mine, so this regression is mine to close.

## The change

One `except UniFiResponseError` clause on the same call. It leaves the site list empty, which is what setup validation in `__init__.py` already does for this console.

Two conditions keep it narrow. A status of 400 or above re-raises, so real client and server errors still fail. The tolerance applies only when a Protect client is configured, so a Network-only console that starts serving HTML fails loudly instead of quietly reporting no sites.

`UniFiNotFoundError` subclasses `UniFiResponseError`, so the new clause sits below the existing tuple. Above it, the 404 path the tuple handles would be swallowed.

## Tests

Three added to `TestUnifiConfigCoordinator`:

- a 200 non-JSON response on a Protect-only console returns empty config and stays available
- the same response with no Protect client raises `UpdateFailed`
- a 500 raises `UpdateFailed`

The first fails on current `main` with the exact error above. Full suite: 1168 passed, coverage 90.51%.

## What I can and cannot vouch for

The failure and the traceback are from v2026.8.3 on that console. I have been running an equivalent tolerance downstream on the same hardware, where both entries load and both Protect WebSocket streams stay connected.

This version is stricter than the one I run, because it also requires a Protect client before tolerating the response. That extra condition is covered by the second test rather than by hardware.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with UniFi consoles that do not have the Network application installed.
  - Initial configuration refreshes no longer fail when the sites endpoint returns an empty or non-JSON response, provided Protect is available.
  - Genuine server errors and configurations without Protect continue to report failures correctly.
  - Improved handling of console-reported WebSocket errors, preventing them from being misclassified as malformed messages.

- **Tests**
  - Added coverage for non-JSON responses, expected error conditions, and WebSocket error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->