### PR TITLE
fix(routes): align PolicyBasedRoute with live UniFi Network 10.6 payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ After setup, open the integration's options flow (**Settings** → **Devices & S
 | WiFi Network        | Enable or disable a WiFi broadcast               |
 | Firewall Rule       | Enable or disable a user-defined firewall policy |
 | Client Allow        | Block or allow a connected network client        |
+| Traffic Route       | Enable or disable a policy-based traffic route   |
+| VPN Client          | Enable or disable a VPN client interface         |
 | Camera Microphone   | Enable or disable the camera microphone          |
 | Camera Privacy Mode | Enable or disable privacy mode                   |
 | Camera Status Light | Enable or disable the status LED                 |

--- a/custom_components/unifi_insights/api/network/models/routes.py
+++ b/custom_components/unifi_insights/api/network/models/routes.py
@@ -2,7 +2,27 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from pydantic import BaseModel, Field
+
+
+class TrafficRouteTargetDevice(BaseModel):
+    """
+    A single entry in a Policy-Based Route's ``target_devices`` list.
+
+    Observed on live UniFi OS 5.1.31 / Network 10.6.101 controllers as e.g.
+    ``{"network_id": "...", "type": "NETWORK"}``. The shape is otherwise
+    undocumented, so every field is optional and unknown extras are kept.
+    """
+
+    type: str | None = None
+    network_id: str | None = Field(default=None, alias="networkId")
+    client_mac: str | None = Field(default=None, alias="clientMac")
+    device_mac: str | None = Field(default=None, alias="deviceMac")
+    ip_address: str | None = Field(default=None, alias="ipAddress")
+
+    model_config = {"populate_by_name": True, "extra": "allow"}
 
 
 class PolicyBasedRoute(BaseModel):
@@ -11,6 +31,22 @@ class PolicyBasedRoute(BaseModel):
 
     Traffic routes allow selective routing of traffic (by domain, IP, client,
     or network) out through a specific WAN interface or VPN Client.
+
+    Two payload shapes are known to occur in the wild:
+
+    - Fields below such as ``target``, ``interface``, ``vpn_client_id``,
+      ``fall_back_to_default_wan``, ``kill_switch`` (singular), ``ips``,
+      ``client_macs``, and ``network_ids`` (plural) come from the
+      maintainer's original console/firmware observations and are kept for
+      backward compatibility -- they have not been reproduced against a live
+      controller during this pass.
+    - Fields such as ``kill_switch_enabled``, ``network_id`` (singular),
+      ``next_hop``, ``regions``, ``ip_ranges``, and ``target_devices`` were
+      captured live from a UniFi Dream Machine SE (UniFi OS 5.1.31, Network
+      10.6.101) via ``GET /proxy/network/v2/api/site/default/trafficroutes``
+      and are verified against real hardware output.
+
+    Both shapes are modelled as optional so either can parse successfully.
     """
 
     id: str = Field(default="", alias="_id")
@@ -22,14 +58,22 @@ class PolicyBasedRoute(BaseModel):
     interface: str | None = None
     vpn_client_id: str | None = Field(default=None, alias="vpnClientId")
     kill_switch: bool | None = Field(default=None, alias="killSwitch")
+    kill_switch_enabled: bool | None = Field(default=None, alias="killSwitchEnabled")
     fall_back_to_default_wan: bool | None = Field(
         default=None, alias="fallBackToDefaultWAN"
     )
-    domains: list[str] = Field(default_factory=list)
-    ip_addresses: list[str] = Field(default_factory=list, alias="ipAddresses")
+    domains: list[Any] = Field(default_factory=list)
+    ip_addresses: list[Any] = Field(default_factory=list, alias="ipAddresses")
+    ip_ranges: list[Any] = Field(default_factory=list, alias="ipRanges")
     ips: list[str] = Field(default_factory=list)
     client_macs: list[str] = Field(default_factory=list, alias="clientMacs")
     network_ids: list[str] = Field(default_factory=list, alias="networkIds")
+    network_id: str | None = Field(default=None, alias="networkId")
+    next_hop: str | None = Field(default=None, alias="nextHop")
+    regions: list[Any] = Field(default_factory=list)
+    target_devices: list[TrafficRouteTargetDevice] = Field(
+        default_factory=list, alias="targetDevices"
+    )
     site_id: str | None = Field(default=None, alias="siteId")
 
     model_config = {"populate_by_name": True, "extra": "allow"}

--- a/custom_components/unifi_insights/coordinators/facade.py
+++ b/custom_components/unifi_insights/coordinators/facade.py
@@ -315,6 +315,15 @@ class UnifiFacadeCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             enabled=enabled,
         )
 
+    def resolve_legacy_site_name(self, site_id: str) -> str:
+        """
+        Resolve the classic site name for a facade (integration API) site id.
+
+        Falls back to ``"default"`` (the standard single-site name) when the
+        legacy site mapping has not resolved yet.
+        """
+        return self._device_coordinator.get_legacy_site_name(site_id) or "default"
+
     async def async_set_policy_based_route_enabled(
         self,
         site_id: str,
@@ -323,7 +332,7 @@ class UnifiFacadeCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         enabled: bool,
     ) -> None:
         """Enable or disable a policy-based route (traffic route)."""
-        site_name = self._device_coordinator.get_legacy_site_name(site_id) or "default"
+        site_name = self.resolve_legacy_site_name(site_id)
         await self._async_execute_api_action(
             f"Unable to update policy-based route {route_id}",
             self.network_client.routes.update_route,
@@ -340,7 +349,7 @@ class UnifiFacadeCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         enabled: bool,
     ) -> None:
         """Enable or disable a VPN client configuration."""
-        site_name = self._device_coordinator.get_legacy_site_name(site_id) or "default"
+        site_name = self.resolve_legacy_site_name(site_id)
         await self._async_execute_api_action(
             f"Unable to update VPN client {client_id}",
             self.network_client.vpn_clients.update_vpn_client,

--- a/custom_components/unifi_insights/switch.py
+++ b/custom_components/unifi_insights/switch.py
@@ -513,14 +513,30 @@ class UnifiInsightsPolicyBasedRouteSwitch(
         return "mdi:routes" if self.is_on else "mdi:routes-clock"
 
     @property
+    def _kill_switch_enabled(self) -> bool | None:
+        """
+        Return the route's kill switch state, if known.
+
+        Prefers the controller's own field names (``kill_switch_enabled`` /
+        ``killSwitchEnabled``), falling back to the maintainer's original
+        ``kill_switch`` / ``killSwitch`` names so both payload shapes work.
+        """
+        route_data = self._get_route_data()
+        for key in (
+            "kill_switch_enabled",
+            "killSwitchEnabled",
+            "killSwitch",
+            "kill_switch",
+        ):
+            if key in route_data:
+                return route_data.get(key)
+        return None
+
+    @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return route metadata useful in automations and debugging."""
         route_data = self._get_route_data()
-        kill_switch = (
-            route_data.get("killSwitch")
-            if "killSwitch" in route_data
-            else route_data.get("kill_switch")
-        )
+        kill_switch = self._kill_switch_enabled
         fall_back = (
             route_data.get("fallBackToDefaultWAN")
             if "fallBackToDefaultWAN" in route_data
@@ -535,7 +551,7 @@ class UnifiInsightsPolicyBasedRouteSwitch(
             "interface": route_data.get("interface"),
             "vpn_client_id": route_data.get("vpnClientId")
             or route_data.get("vpn_client_id"),
-            "kill_switch": kill_switch,
+            "kill_switch_enabled": kill_switch,
             "fall_back_to_default_wan": fall_back,
             "domains": route_data.get("domains", []),
             "ip_addresses": route_data.get("ipAddresses")
@@ -545,6 +561,12 @@ class UnifiInsightsPolicyBasedRouteSwitch(
             or route_data.get("client_macs", []),
             "network_ids": route_data.get("networkIds")
             or route_data.get("network_ids", []),
+            "network_id": route_data.get("networkId") or route_data.get("network_id"),
+            "next_hop": route_data.get("nextHop") or route_data.get("next_hop"),
+            "regions": route_data.get("regions", []),
+            "ip_ranges": route_data.get("ipRanges") or route_data.get("ip_ranges", []),
+            "target_devices": route_data.get("targetDevices")
+            or route_data.get("target_devices", []),
         }
 
     async def _async_set_enabled(self, *, enabled: bool) -> None:
@@ -557,6 +579,15 @@ class UnifiInsightsPolicyBasedRouteSwitch(
             self._site_id,
         )
 
+        if not enabled and self._kill_switch_enabled:
+            _LOGGER.warning(
+                "Disabling policy-based route %s in site %s while its kill switch "
+                "is enabled; matched traffic will keep being dropped instead of "
+                "falling back to the default route",
+                self._route_id,
+                self._site_id,
+            )
+
         await async_call_coordinator_action(
             self.coordinator,
             "async_set_policy_based_route_enabled",
@@ -566,7 +597,7 @@ class UnifiInsightsPolicyBasedRouteSwitch(
             enabled=enabled,
             fallback_factory=lambda: (
                 self.coordinator.network_client.routes.update_route(
-                    "default",
+                    self.coordinator.resolve_legacy_site_name(self._site_id),
                     self._route_id,
                     enabled=enabled,
                 )
@@ -697,7 +728,7 @@ class UnifiInsightsVpnClientSwitch(
             enabled=enabled,
             fallback_factory=lambda: (
                 self.coordinator.network_client.vpn_clients.update_vpn_client(
-                    "default",
+                    self.coordinator.resolve_legacy_site_name(self._site_id),
                     self._client_id,
                     enabled=enabled,
                 )

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock
 
@@ -1005,6 +1006,7 @@ class TestUnifiPolicyBasedRouteSwitch:
         coordinator.network_client = MagicMock()
         coordinator.network_client.routes = MagicMock()
         coordinator.network_client.routes.update_route = AsyncMock()
+        coordinator.resolve_legacy_site_name = MagicMock(return_value="default")
         coordinator.async_request_refresh = AsyncMock()
         coordinator.data = {
             "sites": {"site1": {"id": "site1", "name": "Default"}},
@@ -1100,12 +1102,77 @@ class TestUnifiPolicyBasedRouteSwitch:
         assert attrs["interface"] == "vpn"
         assert attrs["vpn_client_id"] == "vpn123"
         assert attrs["matching_target"] == "DOMAIN"
-        assert attrs["kill_switch"] is True
+        assert attrs["kill_switch_enabled"] is True
         assert attrs["fall_back_to_default_wan"] is False
         assert attrs["domains"] == ["privado.com"]
         assert attrs["ip_addresses"] == ["1.2.3.4"]
         assert attrs["client_macs"] == ["aa:bb:cc:dd:ee:ff"]
         assert attrs["network_ids"] == ["net1"]
+
+    def test_extra_state_attributes_live_controller_payload(
+        self, mock_coordinator: MagicMock
+    ) -> None:
+        """Test attributes for a route shaped like the live controller payload.
+
+        Captured from a UniFi Dream Machine SE (UniFi OS 5.1.31, Network
+        10.6.101): the controller uses ``kill_switch_enabled``, not
+        ``killSwitch``/``kill_switch``, and also sends ``network_id``,
+        ``next_hop``, ``regions``, ``ip_ranges``, and ``target_devices``.
+        """
+        mock_coordinator.data["policy_based_routes"]["site1"]["route3"] = {
+            "id": "route3",
+            "description": "Nord Route",
+            "enabled": True,
+            "matching_target": "INTERNET",
+            "kill_switch_enabled": True,
+            "domains": [],
+            "ip_addresses": [],
+            "ip_ranges": [],
+            "next_hop": "",
+            "regions": [],
+            "network_id": "67678a746c1d8157c66f444e",
+            "target_devices": [
+                {"network_id": "67678b326c1d8157c66f4466", "type": "NETWORK"}
+            ],
+        }
+        switch = UnifiPolicyBasedRouteSwitch(
+            coordinator=mock_coordinator,
+            site_id="site1",
+            route_id="route3",
+        )
+
+        attrs = switch.extra_state_attributes
+        assert attrs["kill_switch_enabled"] is True
+        assert attrs["network_id"] == "67678a746c1d8157c66f444e"
+        assert attrs["next_hop"] == ""
+        assert attrs["regions"] == []
+        assert attrs["ip_ranges"] == []
+        assert attrs["target_devices"] == [
+            {"network_id": "67678b326c1d8157c66f4466", "type": "NETWORK"}
+        ]
+
+    @pytest.mark.asyncio
+    async def test_turn_off_warns_when_kill_switch_enabled_live_payload(
+        self, mock_coordinator: MagicMock, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Test disable warning fires for the live ``kill_switch_enabled`` field."""
+        mock_coordinator.data["policy_based_routes"]["site1"]["route3"] = {
+            "id": "route3",
+            "description": "Nord Route",
+            "enabled": True,
+            "kill_switch_enabled": True,
+        }
+        switch = UnifiPolicyBasedRouteSwitch(
+            coordinator=mock_coordinator,
+            site_id="site1",
+            route_id="route3",
+        )
+        switch.async_write_ha_state = MagicMock()
+
+        with caplog.at_level(logging.WARNING):
+            await switch.async_turn_off()
+
+        assert any("kill switch" in record.message.lower() for record in caplog.records)
 
     def test_icon_changes_with_state(self, mock_coordinator: MagicMock) -> None:
         """Test route switch icon reflects VPN and enabled state."""
@@ -1178,6 +1245,66 @@ class TestUnifiPolicyBasedRouteSwitch:
         )
         switch.async_write_ha_state.assert_called_once()
         mock_coordinator.async_request_refresh.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_turn_on_fallback_uses_resolved_site_name(
+        self, mock_coordinator: MagicMock
+    ) -> None:
+        """Test the fallback path resolves the real site name on multi-site."""
+        mock_coordinator.resolve_legacy_site_name = MagicMock(return_value="mysite")
+        mock_coordinator.data["policy_based_routes"]["site1"]["route1"]["enabled"] = (
+            False
+        )
+        switch = UnifiPolicyBasedRouteSwitch(
+            coordinator=mock_coordinator,
+            site_id="site1",
+            route_id="route1",
+        )
+        switch.async_write_ha_state = MagicMock()
+
+        await switch.async_turn_on()
+
+        mock_coordinator.network_client.routes.update_route.assert_called_once_with(
+            "mysite", "route1", enabled=True
+        )
+
+    @pytest.mark.asyncio
+    async def test_turn_off_warns_when_kill_switch_enabled(
+        self, mock_coordinator: MagicMock, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Test disabling a route with an active kill switch logs a warning."""
+        # route1 has killSwitch=True in the fixture data.
+        switch = UnifiPolicyBasedRouteSwitch(
+            coordinator=mock_coordinator,
+            site_id="site1",
+            route_id="route1",
+        )
+        switch.async_write_ha_state = MagicMock()
+
+        with caplog.at_level(logging.WARNING):
+            await switch.async_turn_off()
+
+        assert any("kill switch" in record.message.lower() for record in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_turn_off_no_warning_when_kill_switch_disabled(
+        self, mock_coordinator: MagicMock, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Test disabling a route without a kill switch logs no warning."""
+        # route2 has no killSwitch key in the fixture data.
+        switch = UnifiPolicyBasedRouteSwitch(
+            coordinator=mock_coordinator,
+            site_id="site1",
+            route_id="route2",
+        )
+        switch.async_write_ha_state = MagicMock()
+
+        with caplog.at_level(logging.WARNING):
+            await switch.async_turn_off()
+
+        assert not any(
+            "kill switch" in record.message.lower() for record in caplog.records
+        )
 
     def test_fallback_device_info_without_gateway(
         self, mock_coordinator: MagicMock
@@ -1269,6 +1396,7 @@ class TestAsyncSetupEntryPolicyBasedRoutes:
         coordinator.network_client.base_url = "https://192.168.1.1"
         coordinator.network_client.routes = MagicMock()
         coordinator.network_client.routes.update_route = AsyncMock()
+        coordinator.resolve_legacy_site_name = MagicMock(return_value="default")
         coordinator.data = {
             "sites": {"site1": {"id": "site1", "name": "Default"}},
             "devices": {},
@@ -1339,6 +1467,7 @@ class TestUnifiVpnClientSwitch:
         coordinator.network_client.base_url = "https://192.168.1.1"
         coordinator.network_client.vpn_clients = MagicMock()
         coordinator.network_client.vpn_clients.update_vpn_client = AsyncMock()
+        coordinator.resolve_legacy_site_name = MagicMock(return_value="default")
         coordinator.async_request_refresh = AsyncMock()
         coordinator.data = {
             "sites": {"site1": {"id": "site1", "name": "Default"}},
@@ -1498,6 +1627,26 @@ class TestUnifiVpnClientSwitch:
         switch.async_write_ha_state.assert_called_once()
         mock_coordinator.async_request_refresh.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_turn_on_fallback_uses_resolved_site_name(
+        self, mock_coordinator: MagicMock
+    ) -> None:
+        """Test the fallback path resolves the real site name on multi-site."""
+        mock_coordinator.resolve_legacy_site_name = MagicMock(return_value="mysite")
+        mock_coordinator.data["vpn_clients"]["site1"]["vpn1"]["enabled"] = False
+        switch = UnifiVpnClientSwitch(
+            coordinator=mock_coordinator,
+            site_id="site1",
+            client_id="vpn1",
+        )
+        switch.async_write_ha_state = MagicMock()
+
+        await switch.async_turn_on()
+
+        mock_update = mock_coordinator.network_client.vpn_clients.update_vpn_client
+        mock_update.assert_called_once_with("mysite", "vpn1", enabled=True)
+        mock_coordinator.async_request_refresh.assert_called_once()
+
     def test_fallback_device_info_without_gateway(
         self, mock_coordinator: MagicMock
     ) -> None:
@@ -1574,6 +1723,7 @@ class TestAsyncSetupEntryVpnClients:
         coordinator.network_client.base_url = "https://192.168.1.1"
         coordinator.network_client.vpn_clients = MagicMock()
         coordinator.network_client.vpn_clients.update_vpn_client = AsyncMock()
+        coordinator.resolve_legacy_site_name = MagicMock(return_value="default")
         coordinator.async_request_refresh = AsyncMock()
         coordinator.data = {
             "sites": {"site1": {"id": "site1", "name": "Default"}},

--- a/tests/test_vendored_api.py
+++ b/tests/test_vendored_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import aiohttp
@@ -1031,6 +1032,93 @@ def test_policy_based_route_model() -> None:
 
     route4: PolicyBasedRoute = PolicyBasedRoute.model_validate({"_id": "r4"})
     assert route4.display_name == "Route r4"
+
+
+# Live payloads captured from a UniFi Dream Machine SE (UniFi OS 5.1.31,
+# Network 10.6.101) via GET /proxy/network/v2/api/site/default/trafficroutes.
+# The controller returns a bare JSON array, and route fields differ from what
+# the maintainer's model previously assumed (see routes.py for details).
+LIVE_ROUTE_INTERNET: dict[str, Any] = {
+    "_id": "67678b976c1d8157c66f44a2",
+    "description": "Nord Route",
+    "domains": [],
+    "enabled": True,
+    "ip_addresses": [],
+    "ip_ranges": [],
+    "kill_switch_enabled": True,
+    "matching_target": "INTERNET",
+    "network_id": "67678a746c1d8157c66f444e",
+    "next_hop": "",
+    "regions": [],
+    "target_devices": [{"network_id": "67678b326c1d8157c66f4466", "type": "NETWORK"}],
+}
+
+LIVE_ROUTE_DOMAIN: dict[str, Any] = {
+    "_id": "6a96d1fb745ac3cf4de10e79",
+    "description": "HA PBR Test",
+    "domains": [{"domain": "pbr-test.example.com", "port_ranges": [], "ports": []}],
+    "enabled": True,
+    "ip_addresses": [],
+    "ip_ranges": [],
+    "kill_switch_enabled": True,
+    "matching_target": "DOMAIN",
+    "network_id": "67678a746c1d8157c66f444e",
+    "next_hop": "",
+    "regions": [],
+    "target_devices": [{"network_id": "67678b326c1d8157c66f4466", "type": "NETWORK"}],
+}
+
+
+def test_policy_based_route_model_parses_live_internet_route() -> None:
+    """Test the live INTERNET-target route payload validates cleanly."""
+    route = PolicyBasedRoute.model_validate(LIVE_ROUTE_INTERNET)
+    assert route.id == "67678b976c1d8157c66f44a2"
+    assert route.kill_switch_enabled is True
+    assert route.network_id == "67678a746c1d8157c66f444e"
+    assert route.next_hop == ""
+    assert route.regions == []
+    assert route.ip_ranges == []
+    assert route.target_devices[0].type == "NETWORK"
+    assert route.target_devices[0].network_id == "67678b326c1d8157c66f4466"
+
+
+def test_policy_based_route_model_parses_live_domain_route() -> None:
+    """Test the live DOMAIN-target route payload validates cleanly.
+
+    This is the payload that previously raised
+    ``ValidationError: domains.0 Input should be a valid string`` because
+    ``domains`` was typed as ``list[str]`` while the controller sends a list
+    of domain objects.
+    """
+    route = PolicyBasedRoute.model_validate(LIVE_ROUTE_DOMAIN)
+    assert route.kill_switch_enabled is True
+    assert route.domains[0]["domain"] == "pbr-test.example.com"
+    assert route.target_devices[0].type == "NETWORK"
+    assert route.target_devices[0].network_id == "67678b326c1d8157c66f4466"
+
+
+async def test_routes_endpoint_list_routes_returns_both_live_routes() -> None:
+    """Test list_routes over the real bare-array response returns both routes.
+
+    Before the model fix, the DOMAIN route failed pydantic validation and
+    was silently skipped by list_routes' per-item try/except, so this
+    returned 1 route instead of 2.
+    """
+    client: UniFiNetworkClient = UniFiNetworkClient(
+        auth=ApiKeyAuth(api_key="test-key"),
+        base_url="https://192.168.1.1",
+        connection_type=ConnectionType.LOCAL,
+    )
+    client._get = AsyncMock(
+        return_value=[LIVE_ROUTE_INTERNET, LIVE_ROUTE_DOMAIN],
+    )
+
+    routes: list[PolicyBasedRoute] = await client.routes.list_routes("default")
+    assert len(routes) == 2
+    assert {r.id for r in routes} == {
+        "67678b976c1d8157c66f44a2",
+        "6a96d1fb745ac3cf4de10e79",
+    }
 
 
 async def test_routes_endpoint_list_routes() -> None:


### PR DESCRIPTION
Thanks for building this out. The VPN client switches on top are a nice addition. I ran #104 against live hardware and hit a data-model mismatch that I don't think is visible without a controller in the loop. Evidence below. I've kept the change additive rather than rewriting your model.

**Verified against:** UniFi Dream Machine SE (`UDMPROSE`), UniFi OS 5.1.31, Network application **10.6.101**.

## What the controller returns

`GET /proxy/network/v2/api/site/default/trafficroutes` — a bare array, not `{"data": [...]}`:

```json
[
  { "_id": "…", "description": "Nord Route", "enabled": true,
    "kill_switch_enabled": true, "matching_target": "INTERNET",
    "network_id": "…", "next_hop": "",
    "domains": [], "ip_addresses": [], "ip_ranges": [], "regions": [],
    "target_devices": [{ "network_id": "…", "type": "NETWORK" }] },

  { "_id": "…", "description": "HA PBR Test", "enabled": true,
    "kill_switch_enabled": true, "matching_target": "DOMAIN",
    "domains": [{ "domain": "…", "port_ranges": [], "ports": [] }], … }
]
```

## Two failures

**1. Domain-based routes never become entities.** `domains` is a list of objects; `PolicyBasedRoute.domains` is `list[str]`:

```
ValidationError: 1 validation error for PolicyBasedRoute
domains.0
  Input should be a valid string [type=string_type,
  input_value={'domain': '…', 'port_ranges': [], 'ports': []}, input_type=dict]
```

`list_routes()` catches per-item and skips at `_LOGGER.debug`, so the entity silently never appears — no warning, no error, just a missing switch. **Over my two live routes, 1 of 2 survives.** Domain matching is the common case for VPN split-tunnelling, so this likely affects most users who'd want this feature.

**2. `kill_switch` is always `None`.** The wire field is `kill_switch_enabled`; the model declares `kill_switch` aliased `killSwitch`. Neither matches, so it parses as `None` while `extra: "allow"` quietly retains the true value as an unread extra. The surviving route publishes `kill_switch: None` for a route whose kill switch is on.

This one has teeth. Disabling a traffic route while its kill switch is active doesn't fall back to the default route — the controller keeps dropping the matched traffic. An automation checking `state_attr(..., 'kill_switch')` gets `None`, reads it as safe, and blackholes the target network.

## Also sent but unmapped

`next_hop`, `ip_ranges`, `regions`, `network_id` (singular), `target_devices`. The last is the "what does this route apply to" data, so it's the one worth having.

## Changes

- **`PolicyBasedRoute`**: added `kill_switch_enabled`, `network_id`, `next_hop`, `regions`, `ip_ranges`, and `target_devices` (new `TrafficRouteTargetDevice` model). Widened `domains` / `ip_addresses` to accept objects.
- **Your existing fields are untouched and still optional** — `target`, `interface`, `vpn_client_id`, `fall_back_to_default_wan`, `ips`, `client_macs`, `network_ids`. I can't reproduce them on my hardware, but I'd rather both shapes parse than delete fields you added for a reason. Your original camelCase model test passes unmodified.
- **One intentional breaking change**: the published attribute is renamed `kill_switch` → `kill_switch_enabled`, matching the controller's field name. One of your tests updated for the new key; the value assertion is unchanged. Happy to revert if you'd rather keep the old name.
- `extra_state_attributes` also exposes `network_id`, `next_hop`, `regions`, `ip_ranges`, `target_devices`.
- Warning logged when a route is disabled while its kill switch is enabled.
- `UnifiFacadeCoordinator.resolve_legacy_site_name()` extracted, replacing the hardcoded `"default"` in both switches' `fallback_factory` and the inline duplicate in both facade methods — 4 call sites down to 1. Traffic routes are site-name-scoped, so the literal is wrong on multi-site controllers.
- README `### Switches` rows for Traffic Route and VPN Client.

## Tests

Both live payloads added verbatim as fixtures. The anchor assertion is that `list_routes()` over the bare array returns **2** routes, not 1 — that fails on the current branch head and passes here.

| | `4dc0f23` | this PR |
|---|---|---|
| pytest | 1220 passed | **1229 passed** |
| coverage | 90.54% | 90.57% |
| ruff check | 72 (pre-existing) | 72 (unchanged) |
| ruff format | clean | clean |
| live routes parsed | **1 of 2** | **2 of 2** |

## What I can't verify

One device, one firmware. If your extra fields come from a different console or Network version, a `trafficroutes` dump from it would let me cover both shapes properly. I also haven't touched the VPN client model — no VPN client configured here — but given the two were modelled together, it's worth checking for the same issue.

