### PR TITLE
fix(switch): use translation key for VPN client switch name

### DIFF
--- a/custom_components/unifi_insights/strings.json
+++ b/custom_components/unifi_insights/strings.json
@@ -338,6 +338,9 @@
       },
       "high_fps_mode": {
         "name": "High FPS Mode"
+      },
+      "vpn_client": {
+        "name": "{vpn_client_name}"
       }
     },
     "select": {

--- a/custom_components/unifi_insights/switch.py
+++ b/custom_components/unifi_insights/switch.py
@@ -609,7 +609,8 @@ class UnifiInsightsVpnClientSwitch(
 
         vpn_client_data = self._get_vpn_client_data()
         vpn_client_name = vpn_client_data.get("name") or "VPN Client"
-        self._attr_name = vpn_client_name
+        self._attr_translation_key = "vpn_client"
+        self._attr_translation_placeholders = {"vpn_client_name": vpn_client_name}
 
         self._attr_device_info = self._build_device_info()
 

--- a/custom_components/unifi_insights/translations/en.json
+++ b/custom_components/unifi_insights/translations/en.json
@@ -320,6 +320,9 @@
       },
       "high_fps_mode": {
         "name": "High FPS Mode"
+      },
+      "vpn_client": {
+        "name": "{vpn_client_name}"
       }
     },
     "select": {

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1398,7 +1398,10 @@ class TestUnifiVpnClientSwitch:
         )
 
         assert switch._attr_unique_id == "site1_vpn1_vpn_client"
-        assert switch._attr_name == "Privado VPN"
+        assert switch._attr_translation_key == "vpn_client"
+        assert switch._attr_translation_placeholders == {
+            "vpn_client_name": "Privado VPN"
+        }
         assert switch._attr_entity_category == EntityCategory.CONFIG
         assert switch._attr_device_info["identifiers"] == {(DOMAIN, "site1_gateway1")}
 


### PR DESCRIPTION
## Summary
- `UnifiInsightsVpnClientSwitch` (shipped in PR #104 / `feat/policy-based-routes`) sets `self._attr_name = vpn_client_name` directly, which bypasses Home Assistant's translation system — the entity never picks up a `translation_key`, so translators can't localize the surrounding label text and any future locale work on this entity is a no-op.
- Switches to `_attr_translation_key = "vpn_client"` + `_attr_translation_placeholders = {"vpn_client_name": ...}`, matching the pattern used by every other dynamically-named entity in this integration (camera switches, etc.).
- Adds the missing `switch.vpn_client` entry to `strings.json` and `translations/en.json` (previously absent entirely, so the key would have rendered blank without this fix).

## Test plan
- [x] `pytest tests/test_switch.py -k "Vpn or vpn"` — 11/11 passed
- [x] `ruff format --check` / `ruff check` on changed files — clean
