### PR TITLE
feat(network): UniFi PDU outlet control and power metering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added support for UniFi Power Distribution Units (PDUs) and SmartPower strips (e.g. USP-PDU-Pro, USP-Strip):
+  - Per-outlet relay switches (`UnifiOutletSwitch`) to toggle power state on individual outlets
+  - Config switches (`UnifiOutletCycleSwitch`) for outlets supporting automatic modem power cycling
+  - Per-outlet metering sensors for metered outlets (power in W, voltage in V, current in A, and power factor)
+  - Device-level power total sensors for AC power consumption and AC power budget
+
 ## [2026.9.0] - 2026-09-02
 
 ### Added

--- a/custom_components/unifi_insights/api/network/__init__.py
+++ b/custom_components/unifi_insights/api/network/__init__.py
@@ -12,10 +12,12 @@ from .models import (
     DeviceType,
     FirewallRule,
     FirewallZone,
+    LegacyOutletMetrics,
     LegacyPortMetrics,
     Network,
     NetworkPurpose,
     NetworkType,
+    Outlet,
     PolicyBasedRoute,
     PortBytesMetrics,
     Site,
@@ -23,6 +25,7 @@ from .models import (
     VpnClient,
     WifiNetwork,
     WifiSecurity,
+    parse_outlet_metrics,
 )
 
 __all__ = [
@@ -34,10 +37,12 @@ __all__ = [
     "DeviceType",
     "FirewallRule",
     "FirewallZone",
+    "LegacyOutletMetrics",
     "LegacyPortMetrics",
     "Network",
     "NetworkPurpose",
     "NetworkType",
+    "Outlet",
     "PolicyBasedRoute",
     "PortBytesMetrics",
     "Site",
@@ -46,4 +51,5 @@ __all__ = [
     "VpnClient",
     "WifiNetwork",
     "WifiSecurity",
+    "parse_outlet_metrics",
 ]

--- a/custom_components/unifi_insights/api/network/endpoints/devices.py
+++ b/custom_components/unifi_insights/api/network/endpoints/devices.py
@@ -5,12 +5,58 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
-from ..models import Device, LegacyPortMetrics, PortBytesMetrics
+from ..models import (
+    Device,
+    LegacyOutletMetrics,
+    LegacyPortMetrics,
+    PortBytesMetrics,
+    parse_outlet_metrics,
+)
 
 if TYPE_CHECKING:
     from ..client import UniFiNetworkClient
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _seed_outlet_overrides(device_dict: dict[str, Any]) -> list[dict[str, Any]]:
+    """
+    Build a full outlet_overrides array from a device's sensed outlet_table.
+
+    The controller treats outlet_overrides as the complete desired state: any
+    outlet missing from the array reverts to its default. A device that has
+    never had an outlet changed reports an empty overrides array, so writing a
+    single-entry array would reset every other outlet. Seeding from the sensed
+    outlet_table preserves the current state of untouched outlets.
+    """
+    outlet_table = device_dict.get("outlet_table")
+    if not isinstance(outlet_table, list):
+        return []
+
+    overrides: list[dict[str, Any]] = []
+    for outlet in outlet_table:
+        if not isinstance(outlet, dict):
+            continue
+
+        index = outlet.get("index")
+        if index is None:
+            index = outlet.get("outlet_idx")
+        try:
+            index_int = int(index)  # type: ignore[arg-type]
+        except TypeError, ValueError:
+            continue
+
+        override: dict[str, Any] = {
+            "index": index_int,
+            "relay_state": bool(outlet.get("relay_state", False)),
+        }
+        if "name" in outlet:
+            override["name"] = outlet["name"]
+        if "cycle_enabled" in outlet:
+            override["cycle_enabled"] = bool(outlet["cycle_enabled"])
+        overrides.append(override)
+
+    return overrides
 
 
 class DevicesEndpoint:
@@ -342,13 +388,13 @@ class DevicesEndpoint:
         def _to_float(value: Any) -> float | None:
             try:
                 return float(value)
-            except (TypeError, ValueError):
+            except TypeError, ValueError:
                 return None
 
         def _to_int(value: Any) -> int | None:
             try:
                 return int(value)
-            except (TypeError, ValueError):
+            except TypeError, ValueError:
                 return None
 
         def _get_port_idx(port: dict[str, Any]) -> int | None:
@@ -436,4 +482,113 @@ class DevicesEndpoint:
             f"/sites/{site_id}/devices/{device_id}/{action}"
         )
         await self._client._post(path)
+        return True
+
+    async def get_outlet_metrics(
+        self,
+        site_name: str,
+        device_mac: str,
+    ) -> LegacyOutletMetrics:
+        """
+        Get normalized legacy outlet metrics for a device.
+
+        Args:
+            site_name: The UniFi site name, for example ``default``.
+            device_mac: The device MAC address used by the legacy endpoint.
+
+        Returns:
+            Normalized outlet metrics and device power totals.
+
+        """
+        legacy = await self.get_legacy_device_stats(site_name, device_mac)
+        return parse_outlet_metrics(legacy)
+
+    async def set_outlet_state(
+        self,
+        site_name: str,
+        device_id: str,
+        outlet_index: int,
+        state: bool,
+        cycle_enabled: bool | None = None,
+        current_device: dict[str, Any] | None = None,
+    ) -> bool:
+        """
+        Set the power relay state and/or cycle_enabled setting on a PDU outlet.
+
+        Performs a read-modify-write on outlet_overrides via the legacy
+        rest/device endpoint.
+
+        Args:
+            site_name: The UniFi site name, for example ``default``.
+            device_id: The legacy device MongoDB _id or device identifier.
+            outlet_index: 1-based outlet index.
+            state: True to turn the outlet ON (relay closed), False to turn
+                it OFF (relay open).
+            cycle_enabled: Optional boolean to enable or disable power
+                cycling on internet loss.
+            current_device: Already-fetched device data (outlet_overrides /
+                outlet_table) to source the read side from, avoiding a GET
+                against the singular ``rest/device/{id}`` route, which is
+                write-only on UniFi OS controllers and 404s on GET.
+
+        Returns:
+            True if successful.
+
+        """
+        device_dict: dict[str, Any] = current_device or {}
+        if not device_dict:
+            path = self._client.build_legacy_api_path(
+                site_name, f"/rest/device/{device_id}"
+            )
+            response = await self._client._get(path)
+            if isinstance(response, dict):
+                data = response.get("data", response)
+                if isinstance(data, list) and data and isinstance(data[0], dict):
+                    device_dict = data[0]
+                elif isinstance(data, dict):
+                    device_dict = data
+
+        target_id = device_dict.get("_id", device_id)
+        raw_overrides = device_dict.get("outlet_overrides")
+        outlet_overrides: list[dict[str, Any]] = []
+        if isinstance(raw_overrides, list):
+            outlet_overrides = [
+                dict(item) for item in raw_overrides if isinstance(item, dict)
+            ]
+
+        if not outlet_overrides:
+            outlet_overrides = _seed_outlet_overrides(device_dict)
+
+        found = False
+        for override in outlet_overrides:
+            idx = override.get("index")
+            if idx is None:
+                idx = override.get("outlet_idx")
+            try:
+                idx_int = int(idx)  # type: ignore[arg-type]
+            except TypeError, ValueError:
+                continue
+
+            if idx_int == outlet_index:
+                override["relay_state"] = state
+                if cycle_enabled is not None:
+                    override["cycle_enabled"] = cycle_enabled
+                found = True
+                break
+
+        if not found:
+            new_override: dict[str, Any] = {
+                "index": outlet_index,
+                "relay_state": state,
+            }
+            if cycle_enabled is not None:
+                new_override["cycle_enabled"] = cycle_enabled
+            outlet_overrides.append(new_override)
+
+        put_path = self._client.build_legacy_api_path(
+            site_name, f"/rest/device/{target_id}"
+        )
+        await self._client._put(
+            put_path, json_data={"outlet_overrides": outlet_overrides}
+        )
         return True

--- a/custom_components/unifi_insights/api/network/endpoints/devices.py
+++ b/custom_components/unifi_insights/api/network/endpoints/devices.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
+from ...exceptions import UniFiValidationError
 from ..models import (
     Device,
     LegacyOutletMetrics,
@@ -526,27 +527,24 @@ class DevicesEndpoint:
                 it OFF (relay open).
             cycle_enabled: Optional boolean to enable or disable power
                 cycling on internet loss.
-            current_device: Already-fetched device data (outlet_overrides /
-                outlet_table) to source the read side from, avoiding a GET
-                against the singular ``rest/device/{id}`` route, which is
-                write-only on UniFi OS controllers and 404s on GET.
+            current_device: Required device snapshot (outlet_overrides /
+                outlet_table) to source the read side from. The singular
+                ``rest/device/{id}`` route is write-only on UniFi OS
+                controllers and 404s on GET, so the caller must supply the
+                snapshot from cached ``/stat/device`` data.
 
         Returns:
             True if successful.
 
+        Raises:
+            UniFiValidationError: If ``current_device`` carries neither an
+                existing ``outlet_overrides`` array nor an ``outlet_table`` to
+                seed one from. The controller treats ``outlet_overrides`` as
+                the complete desired state, so writing a partial array would
+                reset every sibling outlet on the device.
+
         """
         device_dict: dict[str, Any] = current_device or {}
-        if not device_dict:
-            path = self._client.build_legacy_api_path(
-                site_name, f"/rest/device/{device_id}"
-            )
-            response = await self._client._get(path)
-            if isinstance(response, dict):
-                data = response.get("data", response)
-                if isinstance(data, list) and data and isinstance(data[0], dict):
-                    device_dict = data[0]
-                elif isinstance(data, dict):
-                    device_dict = data
 
         target_id = device_dict.get("_id", device_id)
         raw_overrides = device_dict.get("outlet_overrides")
@@ -558,6 +556,15 @@ class DevicesEndpoint:
 
         if not outlet_overrides:
             outlet_overrides = _seed_outlet_overrides(device_dict)
+
+        if not outlet_overrides:
+            msg = (
+                f"Refusing to write outlet {outlet_index} on device {device_id}: "
+                "no outlet_overrides or outlet_table available to seed the full "
+                "override array from. Writing a partial array would reset the "
+                "device's other outlets."
+            )
+            raise UniFiValidationError(msg)
 
         found = False
         for override in outlet_overrides:

--- a/custom_components/unifi_insights/api/network/models/__init__.py
+++ b/custom_components/unifi_insights/api/network/models/__init__.py
@@ -26,8 +26,11 @@ from .device import (
     DeviceSwitchingFeature,
     DeviceType,
     DeviceUplink,
+    LegacyOutletMetrics,
     LegacyPortMetrics,
+    Outlet,
     PortBytesMetrics,
+    parse_outlet_metrics,
 )
 from .dns import DNSPolicy, DNSPolicyMetadata, DNSRecordType
 from .firewall import (
@@ -98,8 +101,11 @@ __all__ = [
     "DeviceSwitchingFeature",
     "DeviceType",
     "DeviceUplink",
+    "LegacyOutletMetrics",
     "LegacyPortMetrics",
+    "Outlet",
     "PortBytesMetrics",
+    "parse_outlet_metrics",
     # DNS
     "DNSPolicy",
     "DNSPolicyMetadata",

--- a/custom_components/unifi_insights/api/network/models/device.py
+++ b/custom_components/unifi_insights/api/network/models/device.py
@@ -179,3 +179,147 @@ class LegacyPortMetrics(BaseModel):
     port_bytes: dict[int, PortBytesMetrics] = Field(default_factory=dict)
 
     model_config = {"populate_by_name": True, "extra": "allow"}
+
+
+class Outlet(BaseModel):
+    """Model representing an outlet on a UniFi PDU or smart strip."""
+
+    index: int
+    name: str | None = None
+    relay_state: bool = False
+    cycle_enabled: bool | None = None
+    outlet_caps: int | None = Field(default=None, alias="outletCaps")
+    outlet_voltage: float | None = Field(default=None, alias="outletVoltage")
+    outlet_current: float | None = Field(default=None, alias="outletCurrent")
+    outlet_power: float | None = Field(default=None, alias="outletPower")
+    outlet_power_factor: float | None = Field(default=None, alias="outletPowerFactor")
+
+    model_config = {"populate_by_name": True, "extra": "allow"}
+
+
+class LegacyOutletMetrics(BaseModel):
+    """Normalized outlet metrics from the legacy Network API."""
+
+    outlets: list[Outlet] = Field(default_factory=list)
+    ac_power_consumption: float | None = None
+    ac_power_budget: float | None = None
+
+    model_config = {"populate_by_name": True, "extra": "allow"}
+
+
+def parse_outlet_metrics(legacy_device: dict[str, Any]) -> LegacyOutletMetrics:
+    """
+    Parse outlet metrics and device-level power totals from legacy device data.
+
+    Args:
+        legacy_device: Raw device dictionary from /stat/device.
+
+    Returns:
+        LegacyOutletMetrics containing normalized outlets and device power totals.
+
+    """
+    if not isinstance(legacy_device, dict):
+        return LegacyOutletMetrics()
+
+    raw_table = legacy_device.get("outlet_table")
+    if not isinstance(raw_table, list):
+        raw_table = []
+
+    def _to_float(value: Any) -> float | None:
+        try:
+            return float(value)
+        except TypeError, ValueError:
+            return None
+
+    def _to_int(value: Any) -> int | None:
+        try:
+            return int(value)
+        except TypeError, ValueError:
+            return None
+
+    outlets: list[Outlet] = []
+    for item in raw_table:
+        if not isinstance(item, dict):
+            continue
+        idx = item.get("index")
+        if idx is None:
+            idx = item.get("outlet_idx") or item.get("outletIdx")
+        idx_int = _to_int(idx)
+        if idx_int is None:
+            continue
+
+        relay_val = item.get("relay_state")
+        if relay_val is None:
+            relay_val = item.get("relayState")
+        if relay_val is None:
+            relay_val = item.get("state")
+        relay_state = bool(relay_val) if relay_val is not None else False
+
+        cycle_val = item.get("cycle_enabled")
+        if cycle_val is None:
+            cycle_val = item.get("cycleEnabled")
+        cycle_enabled = bool(cycle_val) if cycle_val is not None else None
+
+        caps = item.get("outlet_caps")
+        if caps is None:
+            caps = item.get("outletCaps") or item.get("caps")
+
+        voltage = _to_float(
+            item.get("outlet_voltage")
+            if item.get("outlet_voltage") is not None
+            else item.get("outletVoltage", item.get("voltage"))
+        )
+        current = _to_float(
+            item.get("outlet_current")
+            if item.get("outlet_current") is not None
+            else item.get("outletCurrent", item.get("current"))
+        )
+        power = _to_float(
+            item.get("outlet_power")
+            if item.get("outlet_power") is not None
+            else item.get("outletPower", item.get("power"))
+        )
+        power_factor = _to_float(
+            item.get("outlet_power_factor")
+            if item.get("outlet_power_factor") is not None
+            else item.get("outletPowerFactor", item.get("power_factor"))
+        )
+
+        outlets.append(
+            Outlet(
+                index=idx_int,
+                name=item.get("name"),
+                relay_state=relay_state,
+                cycle_enabled=cycle_enabled,
+                outlet_caps=_to_int(caps),
+                outlet_voltage=voltage,
+                outlet_current=current,
+                outlet_power=power,
+                outlet_power_factor=power_factor,
+            )
+        )
+
+    ac_consumption = _to_float(
+        legacy_device.get("outlet_ac_power_consumption")
+        if legacy_device.get("outlet_ac_power_consumption") is not None
+        else legacy_device.get(
+            "outletAcPowerConsumption",
+            legacy_device.get(
+                "ac_power_consumption", legacy_device.get("acPowerConsumption")
+            ),
+        )
+    )
+    ac_budget = _to_float(
+        legacy_device.get("outlet_ac_power_budget")
+        if legacy_device.get("outlet_ac_power_budget") is not None
+        else legacy_device.get(
+            "outletAcPowerBudget",
+            legacy_device.get("ac_power_budget", legacy_device.get("acPowerBudget")),
+        )
+    )
+
+    return LegacyOutletMetrics(
+        outlets=outlets,
+        ac_power_consumption=ac_consumption,
+        ac_power_budget=ac_budget,
+    )

--- a/custom_components/unifi_insights/coordinators/device.py
+++ b/custom_components/unifi_insights/coordinators/device.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import UTC, datetime
 import logging
 import time
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.helpers import device_registry as dr
@@ -16,6 +16,7 @@ from custom_components.unifi_insights.api import (
     UniFiResponseError,
     UniFiTimeoutError,
 )
+from custom_components.unifi_insights.api.network.models import parse_outlet_metrics
 from custom_components.unifi_insights.const import DOMAIN, SCAN_INTERVAL_DEVICE
 
 from .base import UnifiBaseCoordinator
@@ -237,6 +238,51 @@ class UnifiDeviceCoordinator(UnifiBaseCoordinator):
         if ports:
             device_dict["ports"] = ports
 
+    @classmethod
+    def _merge_legacy_outlet_data(
+        cls,
+        device_dict: dict[str, Any],
+        legacy_devices_by_mac: dict[str, dict[str, Any]],
+    ) -> None:
+        """Merge outlet_table and power totals from legacy data into the device."""
+        mac_address = cls._normalize_mac(
+            device_dict.get("macAddress") or device_dict.get("mac")
+        )
+        if mac_address is None:
+            return
+
+        legacy_device = legacy_devices_by_mac.get(mac_address)
+        if legacy_device is None:
+            return
+
+        outlet_metrics = parse_outlet_metrics(legacy_device)
+        if (
+            not outlet_metrics.outlets
+            and outlet_metrics.ac_power_consumption is None
+            and outlet_metrics.ac_power_budget is None
+        ):
+            return
+
+        if "_id" in legacy_device:
+            device_dict["_id"] = legacy_device["_id"]
+
+        if outlet_metrics.outlets:
+            device_dict["outlet_table"] = [
+                outlet.model_dump() for outlet in outlet_metrics.outlets
+            ]
+            if "outlet_overrides" in legacy_device:
+                device_dict["outlet_overrides"] = legacy_device["outlet_overrides"]
+
+        if outlet_metrics.ac_power_consumption is not None:
+            device_dict["outlet_ac_power_consumption"] = (
+                outlet_metrics.ac_power_consumption
+            )
+            device_dict["ac_power_consumption"] = outlet_metrics.ac_power_consumption
+
+        if outlet_metrics.ac_power_budget is not None:
+            device_dict["outlet_ac_power_budget"] = outlet_metrics.ac_power_budget
+            device_dict["ac_power_budget"] = outlet_metrics.ac_power_budget
+
     def _map_legacy_site_names(
         self,
         site_ids: list[str],
@@ -437,6 +483,7 @@ class UnifiDeviceCoordinator(UnifiBaseCoordinator):
                 for device in devices:
                     self._merge_legacy_temperature_data(device, legacy_devices_by_mac)
                     self._merge_legacy_port_data(device, legacy_devices_by_mac)
+                    self._merge_legacy_outlet_data(device, legacy_devices_by_mac)
 
             _LOGGER.debug(
                 "Device coordinator: Site %s - Found %d devices and %d clients",

--- a/custom_components/unifi_insights/coordinators/facade.py
+++ b/custom_components/unifi_insights/coordinators/facade.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import UTC, datetime
 import logging
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -297,6 +297,30 @@ class UnifiFacadeCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self.network_client.devices.restart,
             site_id,
             device_id,
+        )
+
+    async def async_set_outlet_state(
+        self,
+        site_id: str,
+        device_id: str,
+        outlet_index: int,
+        state: bool,
+        cycle_enabled: bool | None = None,
+    ) -> bool:
+        """Set outlet relay state and/or cycle_enabled on a PDU device."""
+        site_name = self._device_coordinator.get_legacy_site_name(site_id) or "default"
+        device_data = self.get_device(site_id, device_id) or {}
+        target_id = device_data.get("_id") or device_id
+
+        return await self._async_execute_api_action(
+            f"Unable to set outlet {outlet_index} state on device {device_id}",
+            self.network_client.devices.set_outlet_state,
+            site_name,
+            target_id,
+            outlet_index,
+            state,
+            cycle_enabled=cycle_enabled,
+            current_device=device_data,
         )
 
     async def async_set_firewall_rule_enabled(

--- a/custom_components/unifi_insights/icons.json
+++ b/custom_components/unifi_insights/icons.json
@@ -54,6 +54,24 @@
       },
       "battery": {
         "default": "mdi:battery"
+      },
+      "ac_power_consumption": {
+        "default": "mdi:flash"
+      },
+      "ac_power_budget": {
+        "default": "mdi:flash-outline"
+      },
+      "outlet_power": {
+        "default": "mdi:flash"
+      },
+      "outlet_voltage": {
+        "default": "mdi:sine-wave"
+      },
+      "outlet_current": {
+        "default": "mdi:current-ac"
+      },
+      "outlet_power_factor": {
+        "default": "mdi:angle-acute"
       }
     },
     "binary_sensor": {
@@ -132,6 +150,9 @@
         "state": {
           "off": "mdi:microphone-off"
         }
+      },
+      "outlet": {
+        "default": "mdi:power-socket-us"
       }
     },
     "select": {

--- a/custom_components/unifi_insights/sensor.py
+++ b/custom_components/unifi_insights/sensor.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 import logging
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.sensor import (
@@ -17,6 +17,8 @@ from homeassistant.const import (
     LIGHT_LUX,
     PERCENTAGE,
     UnitOfDataRate,
+    UnitOfElectricCurrent,
+    UnitOfElectricPotential,
     UnitOfInformation,
     UnitOfPower,
     UnitOfTemperature,
@@ -49,8 +51,10 @@ from .coordinators import UnifiFacadeCoordinator
 from .entity import (
     UnifiInsightsEntity,
     UnifiProtectEntity,
-    get_client_type as _get_client_type,
     get_field,
+)
+from .entity import (
+    get_client_type as _get_client_type,
 )
 
 if TYPE_CHECKING:
@@ -533,7 +537,125 @@ SENSOR_TYPES: tuple[UnifiInsightsSensorEntityDescription, ...] = (
             [c for c in stats.get("clients", []) if _get_client_type(c) == "WIRELESS"]
         ),
     ),
+    UnifiInsightsSensorEntityDescription(
+        key="ac_power_consumption",
+        translation_key="ac_power_consumption",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:flash",
+        value_fn=lambda device: get_field(
+            device,
+            "ac_power_consumption",
+            "acPowerConsumption",
+            "outlet_ac_power_consumption",
+            "outletAcPowerConsumption",
+        ),
+    ),
+    UnifiInsightsSensorEntityDescription(
+        key="ac_power_budget",
+        translation_key="ac_power_budget",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:flash-outline",
+        value_fn=lambda device: get_field(
+            device,
+            "ac_power_budget",
+            "acPowerBudget",
+            "outlet_ac_power_budget",
+            "outletAcPowerBudget",
+        ),
+    ),
 )
+
+# Outlet metering sensor descriptions for UniFi PDUs and smart power strips
+OUTLET_SENSOR_TYPES: tuple[UnifiInsightsSensorEntityDescription, ...] = (
+    # Outlet Power (W)
+    UnifiInsightsSensorEntityDescription(
+        key="power",
+        translation_key="outlet_power",
+        native_unit_of_measurement=UnitOfPower.WATT,
+        device_class=SensorDeviceClass.POWER,
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:flash",
+        value_fn=lambda outlet: (
+            outlet.get("outlet_power")
+            if outlet.get("outlet_power") is not None
+            else outlet.get("outletPower", outlet.get("power"))
+        ),
+    ),
+    # Outlet Voltage (V)
+    UnifiInsightsSensorEntityDescription(
+        key="voltage",
+        translation_key="outlet_voltage",
+        native_unit_of_measurement=UnitOfElectricPotential.VOLT,
+        device_class=SensorDeviceClass.VOLTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:sine-wave",
+        value_fn=lambda outlet: (
+            outlet.get("outlet_voltage")
+            if outlet.get("outlet_voltage") is not None
+            else outlet.get("outletVoltage", outlet.get("voltage"))
+        ),
+    ),
+    # Outlet Current (A)
+    UnifiInsightsSensorEntityDescription(
+        key="current",
+        translation_key="outlet_current",
+        native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
+        device_class=SensorDeviceClass.CURRENT,
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:current-ac",
+        value_fn=lambda outlet: (
+            outlet.get("outlet_current")
+            if outlet.get("outlet_current") is not None
+            else outlet.get("outletCurrent", outlet.get("current"))
+        ),
+    ),
+    # Outlet Power Factor
+    UnifiInsightsSensorEntityDescription(
+        key="power_factor",
+        translation_key="outlet_power_factor",
+        device_class=SensorDeviceClass.POWER_FACTOR,
+        state_class=SensorStateClass.MEASUREMENT,
+        icon="mdi:angle-acute",
+        value_fn=lambda outlet: (
+            outlet.get("outlet_power_factor")
+            if outlet.get("outlet_power_factor") is not None
+            else outlet.get("outletPowerFactor", outlet.get("power_factor"))
+        ),
+    ),
+)
+
+
+def _outlet_has_metering(outlet: dict[str, Any]) -> bool:
+    """Return True when an outlet has metering capability or telemetry."""
+    caps = outlet.get("outlet_caps") or outlet.get("outletCaps")
+    if caps is not None:
+        try:
+            if int(caps) & 2:
+                return True
+        except TypeError, ValueError:
+            pass
+    for key in (
+        "outlet_power",
+        "outletPower",
+        "power",
+        "outlet_voltage",
+        "outletVoltage",
+        "voltage",
+        "outlet_current",
+        "outletCurrent",
+        "current",
+        "outlet_power_factor",
+        "outletPowerFactor",
+        "power_factor",
+    ):
+        if outlet.get(key) is not None:
+            return True
+    return False
+
 
 # Port sensor descriptions for UniFi switches
 # These are templates - actual sensors are created dynamically per port
@@ -768,7 +890,12 @@ def _migrate_sensor_units(
 
     # Build a lookup of current suggested units from sensor descriptions
     expected_units: dict[str, str | None] = {}
-    for desc in (*SENSOR_TYPES, *PORT_SENSOR_TYPES, *PORT_RATE_SENSOR_TYPES):
+    for desc in (
+        *SENSOR_TYPES,
+        *PORT_SENSOR_TYPES,
+        *PORT_RATE_SENSOR_TYPES,
+        *OUTLET_SENSOR_TYPES,
+    ):
         if desc.suggested_unit_of_measurement is not None:
             expected_units[desc.key] = str(desc.suggested_unit_of_measurement)
 
@@ -935,6 +1062,19 @@ async def async_setup_entry(
                     has_any_total = any(stats.get(k) is not None for k in poe_keys)
                     has_ports = isinstance(stats.get("poe_ports"), dict)
                     if not has_any_total and not has_ports:
+                        continue
+
+                # Only create AC power sensors if data is present on the device
+                if description.key in (
+                    "ac_power_consumption",
+                    "ac_power_budget",
+                ):
+                    val = (
+                        description.value_fn(device_data)
+                        if description.value_fn
+                        else None
+                    )
+                    if val is None:
                         continue
 
                 entities.append(
@@ -1212,6 +1352,49 @@ async def async_setup_entry(
                     for description in WAN_SENSOR_TYPES
                 )
 
+            # Add outlet sensors for PDUs and smart power strips with outlet_table
+            outlets = device_data.get("outlet_table", [])
+            if isinstance(outlets, list) and outlets:
+                _LOGGER.debug(
+                    "Device %s has %d outlets, creating outlet sensors",
+                    device_name,
+                    len(outlets),
+                )
+                for outlet in outlets:
+                    if not isinstance(outlet, dict):
+                        continue
+                    idx = outlet.get("index")
+                    if idx is None:
+                        idx = outlet.get("outlet_idx") or outlet.get("outletIdx")
+                    if idx is None:
+                        continue
+                    try:
+                        outlet_idx = int(idx)
+                    except TypeError, ValueError:
+                        continue
+
+                    # Only create metering sensors for outlets that meter
+                    if not _outlet_has_metering(outlet):
+                        _LOGGER.debug(
+                            "Skipping metering sensors for outlet %d on %s (unmetered)",
+                            outlet_idx,
+                            device_name,
+                        )
+                        continue
+
+                    outlet_label = outlet.get("name") or f"Outlet {outlet_idx}"
+                    entities.extend(
+                        UnifiOutletSensor(
+                            coordinator=coordinator,
+                            description=outlet_desc,
+                            site_id=site_id,
+                            device_id=device_id,
+                            outlet_index=outlet_idx,
+                            outlet_name=outlet_label,
+                        )
+                        for outlet_desc in OUTLET_SENSOR_TYPES
+                    )
+
     # Add site-level client count sensors
     for site_id in coordinator.data.get("clients", {}):
         _LOGGER.debug("Creating site-level client count sensors for site %s", site_id)
@@ -1348,6 +1531,8 @@ class UnifiInsightsSensor(UnifiInsightsEntity, SensorEntity):
             "firmware_version",
             "wan_ip",
             "general_temperature",
+            "ac_power_consumption",
+            "ac_power_budget",
         ]:
             device = (
                 self.coordinator.data["devices"]
@@ -1775,6 +1960,95 @@ class UnifiPortSensor(UnifiInsightsEntity, SensorEntity):
         if sfp_found is not None:
             attrs["sfp_module_present"] = sfp_found
         return attrs or None
+
+
+class UnifiOutletSensor(UnifiInsightsEntity, SensorEntity):
+    """Representation of a UniFi Outlet Metering Sensor."""
+
+    entity_description: UnifiInsightsSensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: UnifiFacadeCoordinator,
+        description: UnifiInsightsSensorEntityDescription,
+        site_id: str,
+        device_id: str,
+        *,
+        outlet_index: int,
+        outlet_name: str | None = None,
+    ) -> None:
+        """Initialize the outlet sensor."""
+        super().__init__(coordinator, description, site_id, device_id)
+        self._outlet_index = outlet_index
+        label = outlet_name or f"Outlet {outlet_index}"
+        self._attr_translation_placeholders = {"outlet_name": label}
+        self._attr_unique_id = (
+            f"{site_id}_{device_id}_outlet_{outlet_index}_{description.key}"
+        )
+
+        _LOGGER.debug(
+            "Initializing %s sensor for outlet %d on device %s in site %s",
+            description.key,
+            outlet_index,
+            device_id,
+            site_id,
+        )
+
+    def _find_outlet_data(self) -> dict[str, Any] | None:
+        """Find outlet data for this sensor's outlet index."""
+        device_data = (
+            self.coordinator.data.get("devices", {})
+            .get(self._site_id, {})
+            .get(self._device_id, {})
+        )
+        if not isinstance(device_data, dict):
+            return None
+        outlets = device_data.get("outlet_table", [])
+        if not isinstance(outlets, list):
+            return None
+        for outlet in outlets:
+            if not isinstance(outlet, dict):
+                continue
+            idx = outlet.get("index")
+            if idx is None:
+                idx = outlet.get("outlet_idx") or outlet.get("outletIdx")
+            if idx is not None:
+                try:
+                    if int(idx) == self._outlet_index:
+                        return outlet
+                except TypeError, ValueError:
+                    continue
+        return None
+
+    @property
+    def available(self) -> bool:
+        """Return True if entity is available."""
+        if not super().available:
+            return False
+        return self._find_outlet_data() is not None
+
+    @property
+    def native_value(self) -> StateType:
+        """Return the state of the sensor."""
+        outlet = self._find_outlet_data()
+        if not outlet:
+            return None
+        if self.entity_description.value_fn:
+            return self.entity_description.value_fn(outlet)
+        return None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Return outlet metadata attributes."""
+        outlet = self._find_outlet_data()
+        if not outlet:
+            return None
+        attrs: dict[str, Any] = {"index": self._outlet_index}
+        if "name" in outlet and outlet["name"] is not None:
+            attrs["name"] = outlet["name"]
+        if "relay_state" in outlet and outlet["relay_state"] is not None:
+            attrs["relay_state"] = outlet["relay_state"]
+        return attrs
 
 
 class UnifiProtectSensor(UnifiProtectEntity, SensorEntity):

--- a/custom_components/unifi_insights/strings.json
+++ b/custom_components/unifi_insights/strings.json
@@ -234,6 +234,24 @@
       },
       "site_wireless_clients": {
         "name": "Wireless Clients"
+      },
+      "ac_power_consumption": {
+        "name": "AC Power Consumption"
+      },
+      "ac_power_budget": {
+        "name": "AC Power Budget"
+      },
+      "outlet_power": {
+        "name": "{outlet_name} Power"
+      },
+      "outlet_voltage": {
+        "name": "{outlet_name} Voltage"
+      },
+      "outlet_current": {
+        "name": "{outlet_name} Current"
+      },
+      "outlet_power_factor": {
+        "name": "{outlet_name} Power Factor"
       }
     },
     "binary_sensor": {
@@ -338,6 +356,12 @@
       },
       "high_fps_mode": {
         "name": "High FPS Mode"
+      },
+      "outlet": {
+        "name": "{outlet_name}"
+      },
+      "outlet_cycle_enabled": {
+        "name": "{outlet_name} Power Cycle"
       }
     },
     "select": {

--- a/custom_components/unifi_insights/switch.py
+++ b/custom_components/unifi_insights/switch.py
@@ -30,6 +30,7 @@ from .entity import (
     UnifiProtectEntity,
     async_call_coordinator_action,
     get_field,
+    is_device_online,
 )
 
 if TYPE_CHECKING:
@@ -251,6 +252,50 @@ async def async_setup_entry(
                     rule_id=rule_id,
                 )
             )
+
+    # Add PDU outlet relay and power cycle switches
+    for site_id, devices in coordinator.data.get("devices", {}).items():
+        if not isinstance(devices, dict):
+            continue
+        for device_id, device_data in devices.items():
+            if not isinstance(device_data, dict):
+                continue
+            outlet_table = device_data.get("outlet_table", [])
+            if not isinstance(outlet_table, list):
+                continue
+            for outlet in outlet_table:
+                if not isinstance(outlet, dict):
+                    continue
+                idx = outlet.get("index")
+                if idx is None:
+                    idx = outlet.get("outlet_idx") or outlet.get("outletIdx")
+                if idx is None:
+                    continue
+                try:
+                    outlet_idx = int(idx)
+                except TypeError, ValueError:
+                    continue
+
+                entities.append(
+                    UnifiOutletSwitch(
+                        coordinator=coordinator,
+                        site_id=site_id,
+                        device_id=device_id,
+                        outlet_index=outlet_idx,
+                        outlet_data=outlet,
+                    )
+                )
+
+                if outlet.get("cycle_enabled") is not None:
+                    entities.append(
+                        UnifiOutletCycleSwitch(
+                            coordinator=coordinator,
+                            site_id=site_id,
+                            device_id=device_id,
+                            outlet_index=outlet_idx,
+                            outlet_data=outlet,
+                        )
+                    )
 
     if skipped_system_rules:
         _LOGGER.info(
@@ -1311,4 +1356,411 @@ class UnifiWifiSwitch(CoordinatorEntity["UnifiFacadeCoordinator"], SwitchEntity)
             self._wifi_id,
             self._site_id,
         )
+        await self.coordinator.async_request_refresh()
+
+
+class UnifiOutletSwitch(CoordinatorEntity["UnifiFacadeCoordinator"], SwitchEntity):
+    """Per-outlet relay switch for UniFi PDU and smart power strip devices."""
+
+    _attr_has_entity_name = True
+    _attr_icon = "mdi:power-socket-us"
+
+    def __init__(
+        self,
+        coordinator: UnifiFacadeCoordinator,
+        site_id: str,
+        device_id: str,
+        outlet_index: int,
+        outlet_data: dict[str, Any] | None = None,
+    ) -> None:
+        """Initialize the outlet switch."""
+        super().__init__(coordinator)
+        self._site_id = site_id
+        self._device_id = device_id
+        self._outlet_index = outlet_index
+        self._initial_outlet_data = outlet_data or {}
+
+        outlet = self._get_outlet_data() or self._initial_outlet_data
+        outlet_name = outlet.get("name") or f"Outlet {outlet_index}"
+
+        self._attr_unique_id = f"{site_id}_{device_id}_outlet_{outlet_index}"
+        self._attr_translation_key = "outlet"
+        self._attr_translation_placeholders = {"outlet_name": str(outlet_name)}
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, f"{site_id}_{device_id}")},
+        )
+
+    def _get_outlet_data(self) -> dict[str, Any] | None:
+        """Get current outlet data from coordinator."""
+        device_data = (
+            self.coordinator.data.get("devices", {})
+            .get(self._site_id, {})
+            .get(self._device_id, {})
+        )
+        if not isinstance(device_data, dict):
+            return None
+        outlets = device_data.get("outlet_table", [])
+        if not isinstance(outlets, list):
+            return None
+        for outlet in outlets:
+            if not isinstance(outlet, dict):
+                continue
+            idx = outlet.get("index")
+            if idx is None:
+                idx = outlet.get("outlet_idx") or outlet.get("outletIdx")
+            if idx is not None:
+                try:
+                    if int(idx) == self._outlet_index:
+                        return outlet
+                except TypeError, ValueError:
+                    continue
+        return None
+
+    def _update_local_state(
+        self,
+        *,
+        relay_state: bool | None = None,
+        cycle_enabled: bool | None = None,
+    ) -> None:
+        """Update local coordinator cache for immediate UI feedback."""
+        devices = self.coordinator.data.setdefault("devices", {})
+        site_devices = devices.setdefault(self._site_id, {})
+        device_data = site_devices.get(self._device_id)
+        if isinstance(device_data, dict):
+            outlet_table = device_data.get("outlet_table", [])
+            if isinstance(outlet_table, list):
+                for outlet in outlet_table:
+                    if not isinstance(outlet, dict):
+                        continue
+                    idx = outlet.get("index")
+                    if idx is None:
+                        idx = outlet.get("outlet_idx") or outlet.get("outletIdx")
+                    if idx is not None:
+                        try:
+                            if int(idx) == self._outlet_index:
+                                if relay_state is not None:
+                                    outlet["relay_state"] = relay_state
+                                if cycle_enabled is not None:
+                                    outlet["cycle_enabled"] = cycle_enabled
+                                break
+                        except TypeError, ValueError:
+                            continue
+
+    @property
+    def available(self) -> bool:
+        """Return True if switch is available."""
+        if not self.coordinator.available:
+            return False
+        device_data = (
+            self.coordinator.data.get("devices", {})
+            .get(self._site_id, {})
+            .get(self._device_id, {})
+        )
+        if not device_data or not is_device_online(device_data):
+            return False
+        return self._get_outlet_data() is not None
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if outlet relay is energized (ON)."""
+        outlet = self._get_outlet_data()
+        if not outlet:
+            return bool(self._initial_outlet_data.get("relay_state", False))
+        return bool(outlet.get("relay_state", False))
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return outlet extra state attributes."""
+        outlet = self._get_outlet_data() or self._initial_outlet_data
+        attrs: dict[str, Any] = {"index": self._outlet_index}
+        for key in (
+            "name",
+            "relay_state",
+            "cycle_enabled",
+            "outlet_caps",
+            "outlet_voltage",
+            "outlet_current",
+            "outlet_power",
+            "outlet_power_factor",
+        ):
+            if key in outlet and outlet[key] is not None:
+                attrs[key] = outlet[key]
+        return attrs
+
+    def _get_legacy_site_name(self) -> str:
+        """Resolve legacy site name from device coordinator if available."""
+        if hasattr(self.coordinator, "_device_coordinator"):
+            dev_coord = self.coordinator._device_coordinator
+            if hasattr(dev_coord, "get_legacy_site_name"):
+                val = dev_coord.get_legacy_site_name(self._site_id)
+                if isinstance(val, str) and val:
+                    return val
+        return "default"
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn on the outlet."""
+        _ = kwargs
+        _LOGGER.debug(
+            "Turning on outlet %d for device %s in site %s",
+            self._outlet_index,
+            self._device_id,
+            self._site_id,
+        )
+        site_name = self._get_legacy_site_name()
+
+        await async_call_coordinator_action(
+            self.coordinator,
+            "async_set_outlet_state",
+            (
+                f"Unable to turn on outlet {self._outlet_index} "
+                f"on device {self._device_id}"
+            ),
+            self._site_id,
+            self._device_id,
+            self._outlet_index,
+            state=True,
+            fallback_factory=lambda: (
+                self.coordinator.network_client.devices.set_outlet_state(
+                    site_name,
+                    self._device_id,
+                    self._outlet_index,
+                    state=True,
+                )
+            ),
+        )
+        self._update_local_state(relay_state=True)
+        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off the outlet."""
+        _ = kwargs
+        _LOGGER.debug(
+            "Turning off outlet %d for device %s in site %s",
+            self._outlet_index,
+            self._device_id,
+            self._site_id,
+        )
+        site_name = self._get_legacy_site_name()
+
+        await async_call_coordinator_action(
+            self.coordinator,
+            "async_set_outlet_state",
+            (
+                f"Unable to turn off outlet {self._outlet_index} "
+                f"on device {self._device_id}"
+            ),
+            self._site_id,
+            self._device_id,
+            self._outlet_index,
+            state=False,
+            fallback_factory=lambda: (
+                self.coordinator.network_client.devices.set_outlet_state(
+                    site_name,
+                    self._device_id,
+                    self._outlet_index,
+                    state=False,
+                )
+            ),
+        )
+        self._update_local_state(relay_state=False)
+        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()
+
+
+class UnifiOutletCycleSwitch(CoordinatorEntity["UnifiFacadeCoordinator"], SwitchEntity):
+    """Switch to enable or disable automatic modem power cycling for a PDU outlet."""
+
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_entity_registry_enabled_default = False
+    _attr_icon = "mdi:restart"
+
+    def __init__(
+        self,
+        coordinator: UnifiFacadeCoordinator,
+        site_id: str,
+        device_id: str,
+        outlet_index: int,
+        outlet_data: dict[str, Any] | None = None,
+    ) -> None:
+        """Initialize the outlet cycle switch."""
+        super().__init__(coordinator)
+        self._site_id = site_id
+        self._device_id = device_id
+        self._outlet_index = outlet_index
+        self._initial_outlet_data = outlet_data or {}
+
+        outlet = self._get_outlet_data() or self._initial_outlet_data
+        outlet_name = outlet.get("name") or f"Outlet {outlet_index}"
+
+        self._attr_unique_id = (
+            f"{site_id}_{device_id}_outlet_{outlet_index}_cycle_enabled"
+        )
+        self._attr_translation_key = "outlet_cycle_enabled"
+        self._attr_translation_placeholders = {"outlet_name": str(outlet_name)}
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, f"{site_id}_{device_id}")},
+        )
+
+    def _get_outlet_data(self) -> dict[str, Any] | None:
+        """Get current outlet data from coordinator."""
+        device_data = (
+            self.coordinator.data.get("devices", {})
+            .get(self._site_id, {})
+            .get(self._device_id, {})
+        )
+        if not isinstance(device_data, dict):
+            return None
+        outlets = device_data.get("outlet_table", [])
+        if not isinstance(outlets, list):
+            return None
+        for outlet in outlets:
+            if not isinstance(outlet, dict):
+                continue
+            idx = outlet.get("index")
+            if idx is None:
+                idx = outlet.get("outlet_idx") or outlet.get("outletIdx")
+            if idx is not None:
+                try:
+                    if int(idx) == self._outlet_index:
+                        return outlet
+                except TypeError, ValueError:
+                    continue
+        return None
+
+    def _update_local_state(
+        self,
+        *,
+        cycle_enabled: bool,
+    ) -> None:
+        """Update local coordinator cache for immediate UI feedback."""
+        devices = self.coordinator.data.setdefault("devices", {})
+        site_devices = devices.setdefault(self._site_id, {})
+        device_data = site_devices.get(self._device_id)
+        if isinstance(device_data, dict):
+            outlet_table = device_data.get("outlet_table", [])
+            if isinstance(outlet_table, list):
+                for outlet in outlet_table:
+                    if not isinstance(outlet, dict):
+                        continue
+                    idx = outlet.get("index")
+                    if idx is None:
+                        idx = outlet.get("outlet_idx") or outlet.get("outletIdx")
+                    if idx is not None:
+                        try:
+                            if int(idx) == self._outlet_index:
+                                outlet["cycle_enabled"] = cycle_enabled
+                                break
+                        except TypeError, ValueError:
+                            continue
+
+    @property
+    def available(self) -> bool:
+        """Return True if switch is available."""
+        if not self.coordinator.available:
+            return False
+        device_data = (
+            self.coordinator.data.get("devices", {})
+            .get(self._site_id, {})
+            .get(self._device_id, {})
+        )
+        if not device_data or not is_device_online(device_data):
+            return False
+        return self._get_outlet_data() is not None
+
+    @property
+    def is_on(self) -> bool:
+        """Return True if power cycling is enabled on this outlet."""
+        outlet = self._get_outlet_data()
+        if not outlet:
+            return bool(self._initial_outlet_data.get("cycle_enabled", False))
+        return bool(outlet.get("cycle_enabled", False))
+
+    def _get_legacy_site_name(self) -> str:
+        """Resolve legacy site name from device coordinator if available."""
+        if hasattr(self.coordinator, "_device_coordinator"):
+            dev_coord = self.coordinator._device_coordinator
+            if hasattr(dev_coord, "get_legacy_site_name"):
+                val = dev_coord.get_legacy_site_name(self._site_id)
+                if isinstance(val, str) and val:
+                    return val
+        return "default"
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Enable power cycling on the outlet."""
+        _ = kwargs
+        _LOGGER.debug(
+            "Enabling power cycle for outlet %d on device %s in site %s",
+            self._outlet_index,
+            self._device_id,
+            self._site_id,
+        )
+        outlet = self._get_outlet_data() or self._initial_outlet_data
+        current_relay = bool(outlet.get("relay_state", True))
+        site_name = self._get_legacy_site_name()
+
+        await async_call_coordinator_action(
+            self.coordinator,
+            "async_set_outlet_state",
+            (
+                f"Unable to enable power cycle on outlet {self._outlet_index} "
+                f"on device {self._device_id}"
+            ),
+            self._site_id,
+            self._device_id,
+            self._outlet_index,
+            state=current_relay,
+            cycle_enabled=True,
+            fallback_factory=lambda: (
+                self.coordinator.network_client.devices.set_outlet_state(
+                    site_name,
+                    self._device_id,
+                    self._outlet_index,
+                    state=current_relay,
+                    cycle_enabled=True,
+                )
+            ),
+        )
+        self._update_local_state(cycle_enabled=True)
+        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Disable power cycling on the outlet."""
+        _ = kwargs
+        _LOGGER.debug(
+            "Disabling power cycle for outlet %d on device %s in site %s",
+            self._outlet_index,
+            self._device_id,
+            self._site_id,
+        )
+        outlet = self._get_outlet_data() or self._initial_outlet_data
+        current_relay = bool(outlet.get("relay_state", True))
+        site_name = self._get_legacy_site_name()
+
+        await async_call_coordinator_action(
+            self.coordinator,
+            "async_set_outlet_state",
+            (
+                f"Unable to disable power cycle on outlet {self._outlet_index} "
+                f"on device {self._device_id}"
+            ),
+            self._site_id,
+            self._device_id,
+            self._outlet_index,
+            state=current_relay,
+            cycle_enabled=False,
+            fallback_factory=lambda: (
+                self.coordinator.network_client.devices.set_outlet_state(
+                    site_name,
+                    self._device_id,
+                    self._outlet_index,
+                    state=current_relay,
+                    cycle_enabled=False,
+                )
+            ),
+        )
+        self._update_local_state(cycle_enabled=False)
+        self.async_write_ha_state()
         await self.coordinator.async_request_refresh()

--- a/custom_components/unifi_insights/switch.py
+++ b/custom_components/unifi_insights/switch.py
@@ -1390,14 +1390,19 @@ class UnifiOutletSwitch(CoordinatorEntity["UnifiFacadeCoordinator"], SwitchEntit
             identifiers={(DOMAIN, f"{site_id}_{device_id}")},
         )
 
-    def _get_outlet_data(self) -> dict[str, Any] | None:
-        """Get current outlet data from coordinator."""
+    def _get_device_data(self) -> dict[str, Any]:
+        """Return the coordinator's cached snapshot for this PDU device."""
         device_data = (
             self.coordinator.data.get("devices", {})
             .get(self._site_id, {})
             .get(self._device_id, {})
         )
-        if not isinstance(device_data, dict):
+        return device_data if isinstance(device_data, dict) else {}
+
+    def _get_outlet_data(self) -> dict[str, Any] | None:
+        """Get current outlet data from coordinator."""
+        device_data = self._get_device_data()
+        if not device_data:
             return None
         outlets = device_data.get("outlet_table", [])
         if not isinstance(outlets, list):
@@ -1451,11 +1456,7 @@ class UnifiOutletSwitch(CoordinatorEntity["UnifiFacadeCoordinator"], SwitchEntit
         """Return True if switch is available."""
         if not self.coordinator.available:
             return False
-        device_data = (
-            self.coordinator.data.get("devices", {})
-            .get(self._site_id, {})
-            .get(self._device_id, {})
-        )
+        device_data = self._get_device_data()
         if not device_data or not is_device_online(device_data):
             return False
         return self._get_outlet_data() is not None
@@ -1488,14 +1489,8 @@ class UnifiOutletSwitch(CoordinatorEntity["UnifiFacadeCoordinator"], SwitchEntit
         return attrs
 
     def _get_legacy_site_name(self) -> str:
-        """Resolve legacy site name from device coordinator if available."""
-        if hasattr(self.coordinator, "_device_coordinator"):
-            dev_coord = self.coordinator._device_coordinator
-            if hasattr(dev_coord, "get_legacy_site_name"):
-                val = dev_coord.get_legacy_site_name(self._site_id)
-                if isinstance(val, str) and val:
-                    return val
-        return "default"
+        """Resolve the legacy site name via the facade coordinator."""
+        return self.coordinator.resolve_legacy_site_name(self._site_id)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the outlet."""
@@ -1525,6 +1520,7 @@ class UnifiOutletSwitch(CoordinatorEntity["UnifiFacadeCoordinator"], SwitchEntit
                     self._device_id,
                     self._outlet_index,
                     state=True,
+                    current_device=self._get_device_data(),
                 )
             ),
         )
@@ -1560,6 +1556,7 @@ class UnifiOutletSwitch(CoordinatorEntity["UnifiFacadeCoordinator"], SwitchEntit
                     self._device_id,
                     self._outlet_index,
                     state=False,
+                    current_device=self._get_device_data(),
                 )
             ),
         )
@@ -1603,14 +1600,19 @@ class UnifiOutletCycleSwitch(CoordinatorEntity["UnifiFacadeCoordinator"], Switch
             identifiers={(DOMAIN, f"{site_id}_{device_id}")},
         )
 
-    def _get_outlet_data(self) -> dict[str, Any] | None:
-        """Get current outlet data from coordinator."""
+    def _get_device_data(self) -> dict[str, Any]:
+        """Return the coordinator's cached snapshot for this PDU device."""
         device_data = (
             self.coordinator.data.get("devices", {})
             .get(self._site_id, {})
             .get(self._device_id, {})
         )
-        if not isinstance(device_data, dict):
+        return device_data if isinstance(device_data, dict) else {}
+
+    def _get_outlet_data(self) -> dict[str, Any] | None:
+        """Get current outlet data from coordinator."""
+        device_data = self._get_device_data()
+        if not device_data:
             return None
         outlets = device_data.get("outlet_table", [])
         if not isinstance(outlets, list):
@@ -1660,14 +1662,15 @@ class UnifiOutletCycleSwitch(CoordinatorEntity["UnifiFacadeCoordinator"], Switch
         """Return True if switch is available."""
         if not self.coordinator.available:
             return False
-        device_data = (
-            self.coordinator.data.get("devices", {})
-            .get(self._site_id, {})
-            .get(self._device_id, {})
-        )
+        device_data = self._get_device_data()
         if not device_data or not is_device_online(device_data):
             return False
         return self._get_outlet_data() is not None
+
+    def _get_current_relay_state(self) -> bool:
+        """Return the outlet's reported relay state, defaulting to OFF."""
+        outlet = self._get_outlet_data() or self._initial_outlet_data
+        return bool(outlet.get("relay_state", False))
 
     @property
     def is_on(self) -> bool:
@@ -1678,14 +1681,8 @@ class UnifiOutletCycleSwitch(CoordinatorEntity["UnifiFacadeCoordinator"], Switch
         return bool(outlet.get("cycle_enabled", False))
 
     def _get_legacy_site_name(self) -> str:
-        """Resolve legacy site name from device coordinator if available."""
-        if hasattr(self.coordinator, "_device_coordinator"):
-            dev_coord = self.coordinator._device_coordinator
-            if hasattr(dev_coord, "get_legacy_site_name"):
-                val = dev_coord.get_legacy_site_name(self._site_id)
-                if isinstance(val, str) and val:
-                    return val
-        return "default"
+        """Resolve the legacy site name via the facade coordinator."""
+        return self.coordinator.resolve_legacy_site_name(self._site_id)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Enable power cycling on the outlet."""
@@ -1696,8 +1693,7 @@ class UnifiOutletCycleSwitch(CoordinatorEntity["UnifiFacadeCoordinator"], Switch
             self._device_id,
             self._site_id,
         )
-        outlet = self._get_outlet_data() or self._initial_outlet_data
-        current_relay = bool(outlet.get("relay_state", True))
+        current_relay = self._get_current_relay_state()
         site_name = self._get_legacy_site_name()
 
         await async_call_coordinator_action(
@@ -1719,6 +1715,7 @@ class UnifiOutletCycleSwitch(CoordinatorEntity["UnifiFacadeCoordinator"], Switch
                     self._outlet_index,
                     state=current_relay,
                     cycle_enabled=True,
+                    current_device=self._get_device_data(),
                 )
             ),
         )
@@ -1735,8 +1732,7 @@ class UnifiOutletCycleSwitch(CoordinatorEntity["UnifiFacadeCoordinator"], Switch
             self._device_id,
             self._site_id,
         )
-        outlet = self._get_outlet_data() or self._initial_outlet_data
-        current_relay = bool(outlet.get("relay_state", True))
+        current_relay = self._get_current_relay_state()
         site_name = self._get_legacy_site_name()
 
         await async_call_coordinator_action(
@@ -1758,6 +1754,7 @@ class UnifiOutletCycleSwitch(CoordinatorEntity["UnifiFacadeCoordinator"], Switch
                     self._outlet_index,
                     state=current_relay,
                     cycle_enabled=False,
+                    current_device=self._get_device_data(),
                 )
             ),
         )

--- a/custom_components/unifi_insights/translations/en.json
+++ b/custom_components/unifi_insights/translations/en.json
@@ -231,6 +231,24 @@
       },
       "site_wireless_clients": {
         "name": "Wireless Clients"
+      },
+      "ac_power_consumption": {
+        "name": "AC Power Consumption"
+      },
+      "ac_power_budget": {
+        "name": "AC Power Budget"
+      },
+      "outlet_power": {
+        "name": "{outlet_name} Power"
+      },
+      "outlet_voltage": {
+        "name": "{outlet_name} Voltage"
+      },
+      "outlet_current": {
+        "name": "{outlet_name} Current"
+      },
+      "outlet_power_factor": {
+        "name": "{outlet_name} Power Factor"
       }
     },
     "binary_sensor": {
@@ -320,6 +338,12 @@
       },
       "high_fps_mode": {
         "name": "High FPS Mode"
+      },
+      "outlet": {
+        "name": "{outlet_name}"
+      },
+      "outlet_cycle_enabled": {
+        "name": "{outlet_name} Power Cycle"
       }
     },
     "select": {

--- a/tests/fixtures/library_responses.py
+++ b/tests/fixtures/library_responses.py
@@ -31,6 +31,71 @@ SAMPLE_CLIENT = {
     "site": "default",
 }
 
+SAMPLE_PDU_DEVICE = {
+    "id": "pdu_device_1",
+    "mac": "00:11:22:33:44:55",
+    "model": "USP-PDU-Pro",
+    "name": "Server Room PDU",
+    "status": "online",
+    "state": "ONLINE",
+    "adopted": True,
+    "firmware_version": "6.6.65",
+    "site": "default",
+    "site_id": "default",
+}
+
+SAMPLE_PDU_LEGACY_DEVICE = {
+    "_id": "60a1b2c3d4e5f67890123456",
+    "mac": "00:11:22:33:44:55",
+    "model": "USP-PDU-Pro",
+    "name": "Server Room PDU",
+    "outlet_ac_power_consumption": "245.50",
+    "outlet_ac_power_budget": "1800.00",
+    "outlet_table": [
+        {
+            "index": 1,
+            "name": "Main Server",
+            "relay_state": True,
+            "cycle_enabled": True,
+            "outlet_caps": 3,
+            "outlet_voltage": "120.2",
+            "outlet_current": "1.25",
+            "outlet_power": "150.0",
+            "outlet_power_factor": "0.98",
+        },
+        {
+            "index": 2,
+            "name": "Backup Server",
+            "relay_state": False,
+            "cycle_enabled": False,
+            "outlet_caps": 3,
+            "outlet_voltage": "120.1",
+            "outlet_current": "0.00",
+            "outlet_power": "0.0",
+            "outlet_power_factor": "0.00",
+        },
+        {
+            "index": 3,
+            "name": "Unmetered Switch",
+            "relay_state": True,
+            "cycle_enabled": None,
+            "outlet_caps": 1,
+            "outlet_voltage": None,
+            "outlet_current": None,
+            "outlet_power": None,
+            "outlet_power_factor": None,
+        },
+    ],
+    "outlet_overrides": [
+        {
+            "index": 1,
+            "name": "Main Server",
+            "relay_state": True,
+            "cycle_enabled": True,
+        },
+    ],
+}
+
 # Protect API responses
 SAMPLE_PROTECT_CAMERA = {
     "id": "test_camera_1",

--- a/tests/test_coordinators.py
+++ b/tests/test_coordinators.py
@@ -3663,6 +3663,7 @@ class TestUnifiFacadeCoordinator:
         result = await facade_coordinator.async_set_outlet_state(
             "site1", "device1", 1, state=True, cycle_enabled=False
         )
+        assert result is True
         set_outlet = facade_coordinator.network_client.devices.set_outlet_state
         set_outlet.assert_called_once_with(
             "branch",

--- a/tests/test_coordinators.py
+++ b/tests/test_coordinators.py
@@ -3,15 +3,15 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import timedelta
 import logging
+from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from homeassistant.const import CONF_API_KEY, CONF_HOST, CONF_VERIFY_SSL
 from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from homeassistant.helpers.update_coordinator import UpdateFailed
-import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.unifi_insights.api import (
@@ -928,6 +928,93 @@ class TestUnifiDeviceCoordinator:
         assert device_data["generalTemperature"] == 47.5
         assert device_data["hasTemperature"] is True
         assert device_data["temperatures"][0]["name"] == "CPU"
+
+    @pytest.mark.asyncio
+    async def test_async_update_data_merges_legacy_outlets(
+        self, coordinator: UnifiDeviceCoordinator
+    ):
+        """Test merge of legacy outlet table and power totals into device data."""
+        coordinator.network_client.devices.get_legacy_site_devices = AsyncMock(
+            return_value=[
+                {
+                    "_id": "60a1b2c3d4e5f67890123456",
+                    "mac": "AA:BB:CC:DD:EE:FF",
+                    "outlet_ac_power_consumption": "245.50",
+                    "outlet_ac_power_budget": "1800.00",
+                    "outlet_table": [
+                        {
+                            "index": 1,
+                            "name": "Outlet 1",
+                            "relay_state": True,
+                            "cycle_enabled": True,
+                            "outlet_caps": 3,
+                            "outlet_voltage": "120.2",
+                            "outlet_current": "1.25",
+                            "outlet_power": "150.0",
+                            "outlet_power_factor": "0.98",
+                        }
+                    ],
+                    "outlet_overrides": [
+                        {
+                            "index": 1,
+                            "relay_state": True,
+                            "cycle_enabled": True,
+                        }
+                    ],
+                }
+            ]
+        )
+
+        result = await coordinator._async_update_data()
+
+        device_data = result["devices"]["default"]["device1"]
+        assert device_data["_id"] == "60a1b2c3d4e5f67890123456"
+        assert device_data["ac_power_consumption"] == 245.5
+        assert device_data["ac_power_budget"] == 1800.0
+        assert len(device_data["outlet_table"]) == 1
+        assert device_data["outlet_table"][0]["name"] == "Outlet 1"
+        assert device_data["outlet_table"][0]["relay_state"] is True
+        assert device_data["outlet_table"][0]["cycle_enabled"] is True
+        assert device_data["outlet_table"][0]["outlet_power"] == 150.0
+        assert len(device_data["outlet_overrides"]) == 1
+
+    def test_merge_legacy_outlet_data_edge_cases(
+        self, coordinator: UnifiDeviceCoordinator
+    ):
+        """Test _merge_legacy_outlet_data edge cases."""
+        # 1. Missing MAC in device_dict
+        dev: dict[str, Any] = {"name": "No MAC"}
+        coordinator._merge_legacy_outlet_data(
+            dev, {"aa:bb:cc:dd:ee:ff": {"outlet_table": [{"index": 1}]}}
+        )
+        assert "outlet_table" not in dev
+
+        # 2. Legacy device not in legacy_devices_by_mac
+        dev = {"mac": "AA:BB:CC:DD:EE:FF"}
+        coordinator._merge_legacy_outlet_data(dev, {})
+        assert "outlet_table" not in dev
+
+        # 3. Legacy device has no outlets and no power totals
+        dev = {"mac": "AA:BB:CC:DD:EE:FF"}
+        coordinator._merge_legacy_outlet_data(
+            dev, {"aa:bb:cc:dd:ee:ff": {"name": "Empty"}}
+        )
+        assert "outlet_table" not in dev
+
+        # 4. Legacy device has only ac_power_consumption
+        dev = {"mac": "AA:BB:CC:DD:EE:FF"}
+        coordinator._merge_legacy_outlet_data(
+            dev, {"aa:bb:cc:dd:ee:ff": {"outlet_ac_power_consumption": "50.5"}}
+        )
+        assert dev["ac_power_consumption"] == 50.5
+        assert "outlet_table" not in dev
+
+        # 5. Legacy device has only ac_power_budget
+        dev = {"mac": "AA:BB:CC:DD:EE:FF"}
+        coordinator._merge_legacy_outlet_data(
+            dev, {"aa:bb:cc:dd:ee:ff": {"outlet_ac_power_budget": "100.0"}}
+        )
+        assert dev["ac_power_budget"] == 100.0
 
     @pytest.mark.asyncio
     async def test_async_update_data_legacy_temperature_failure_is_ignored(
@@ -3552,6 +3639,42 @@ class TestUnifiFacadeCoordinator:
         await facade_coordinator.async_block_client("site1", "client1")
         facade_coordinator.network_client.clients.block.assert_called_once_with(
             "branch", "AA:BB:CC:DD:EE:FF"
+        )
+
+    @pytest.mark.asyncio
+    async def test_async_set_outlet_state(
+        self, facade_coordinator: UnifiFacadeCoordinator
+    ):
+        """Test async_set_outlet_state resolves site and targets legacy _id."""
+        facade_coordinator.data["devices"] = {
+            "site1": {
+                "device1": {
+                    "id": "device1",
+                    "_id": "60a1b2c3d4e5f67890123456",
+                    "macAddress": "AA:BB:CC:DD:EE:FF",
+                }
+            }
+        }
+        facade_coordinator._device_coordinator._legacy_site_names = {"site1": "branch"}
+        facade_coordinator.network_client.devices.set_outlet_state = AsyncMock(
+            return_value=True
+        )
+
+        result = await facade_coordinator.async_set_outlet_state(
+            "site1", "device1", 1, state=True, cycle_enabled=False
+        )
+        set_outlet = facade_coordinator.network_client.devices.set_outlet_state
+        set_outlet.assert_called_once_with(
+            "branch",
+            "60a1b2c3d4e5f67890123456",
+            1,
+            True,
+            cycle_enabled=False,
+            current_device={
+                "id": "device1",
+                "_id": "60a1b2c3d4e5f67890123456",
+                "macAddress": "AA:BB:CC:DD:EE:FF",
+            },
         )
 
     @pytest.mark.asyncio

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -3,14 +3,15 @@
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from homeassistant.const import PERCENTAGE, UnitOfInformation, UnitOfTemperature
 import pytest
+from homeassistant.const import PERCENTAGE, UnitOfInformation, UnitOfTemperature
 
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
 from custom_components.unifi_insights.sensor import (
     NVR_SENSOR_TYPES,
+    OUTLET_SENSOR_TYPES,
     PARALLEL_UPDATES,
     PORT_SENSOR_TYPES,
     PROTECT_SENSOR_TYPES,
@@ -18,6 +19,7 @@ from custom_components.unifi_insights.sensor import (
     SFP_SENSOR_TYPES,
     SITE_CLIENT_SENSOR_TYPES,
     UnifiInsightsSensor,
+    UnifiOutletSensor,
     UnifiPortSensor,
     UnifiProtectNVRSensor,
     UnifiProtectSensor,
@@ -32,6 +34,7 @@ from custom_components.unifi_insights.sensor import (
     _has_protect_stat,
     _has_storage_info,
     _migrate_sensor_units,
+    _outlet_has_metering,
     async_setup_entry,
     bytes_to_bits,
     bytes_to_megabits,
@@ -2799,3 +2802,317 @@ class TestProtectSensorCapabilityFiltering:
         assert "temperature" not in sensor_keys
         assert "humidity" not in sensor_keys
         assert "light" not in sensor_keys
+
+
+class TestUnifiOutletSensor:
+    """Tests for UnifiOutletSensor platform entity."""
+
+    @pytest.fixture
+    def mock_coordinator(self) -> MagicMock:
+        """Create mock coordinator with PDU device data."""
+        coordinator = MagicMock()
+        coordinator.available = True
+        coordinator.last_update_success = True
+        coordinator.protect_client = None
+        coordinator.data = {
+            "sites": {"site1": {"id": "site1", "name": "Default"}},
+            "devices": {
+                "site1": {
+                    "pdu1": {
+                        "id": "pdu1",
+                        "_id": "60a1b2c3d4e5f67890123456",
+                        "name": "Server Room PDU",
+                        "status": "online",
+                        "state": "ONLINE",
+                        "ac_power_consumption": 245.5,
+                        "ac_power_budget": 1800.0,
+                        "features": [],
+                        "outlet_table": [
+                            {
+                                "index": 1,
+                                "name": "Main Server",
+                                "relay_state": True,
+                                "cycle_enabled": True,
+                                "outlet_caps": 3,
+                                "outlet_voltage": 120.2,
+                                "outlet_current": 1.25,
+                                "outlet_power": 150.0,
+                                "outlet_power_factor": 0.98,
+                            },
+                            {
+                                "index": 2,
+                                "name": "Backup Server",
+                                "relay_state": False,
+                                "cycle_enabled": False,
+                                "outlet_caps": 3,
+                                "outlet_voltage": 120.1,
+                                "outlet_current": 0.0,
+                                "outlet_power": 0.0,
+                                "outlet_power_factor": 0.0,
+                            },
+                            {
+                                "index": 3,
+                                "name": "Unmetered Outlet",
+                                "relay_state": True,
+                                "cycle_enabled": None,
+                                "outlet_caps": 1,
+                                "outlet_voltage": None,
+                                "outlet_current": None,
+                                "outlet_power": None,
+                                "outlet_power_factor": None,
+                            },
+                        ],
+                    }
+                }
+            },
+            "stats": {"site1": {"pdu1": {}}},
+            "clients": {},
+            "wifi": {},
+        }
+        coordinator.get_site = MagicMock(
+            return_value=coordinator.data["sites"]["site1"]
+        )
+        return coordinator
+
+    async def test_setup_creates_outlet_metering_sensors(
+        self, hass: HomeAssistant, mock_coordinator, mock_config_entry
+    ) -> None:
+        """Test async_setup_entry creates UnifiOutletSensor instances only for
+        metered outlets."""
+        mock_config_entry.runtime_data.coordinator = mock_coordinator
+        added_entities: list = []
+
+        def add_entities(new_entities, **kwargs):
+            added_entities.extend(new_entities)
+
+        await async_setup_entry(hass, mock_config_entry, add_entities)
+
+        outlet_sensors = [e for e in added_entities if isinstance(e, UnifiOutletSensor)]
+        # Outlets 1 & 2 are metered (4 sensors each = 8);
+        # outlet 3 is unmetered (0 sensors)
+        assert len(outlet_sensors) == 8
+
+        unique_ids = {e.unique_id for e in outlet_sensors}
+        assert "site1_pdu1_outlet_1_power" in unique_ids
+        assert "site1_pdu1_outlet_1_voltage" in unique_ids
+        assert "site1_pdu1_outlet_1_current" in unique_ids
+        assert "site1_pdu1_outlet_1_power_factor" in unique_ids
+
+        assert "site1_pdu1_outlet_2_power" in unique_ids
+        assert "site1_pdu1_outlet_2_voltage" in unique_ids
+        assert "site1_pdu1_outlet_2_current" in unique_ids
+        assert "site1_pdu1_outlet_2_power_factor" in unique_ids
+
+        # Outlet 3 should not have any sensors
+        assert "site1_pdu1_outlet_3_power" not in unique_ids
+
+    def test_outlet_metering_sensor_properties_and_values(
+        self, mock_coordinator
+    ) -> None:
+        """Test UnifiOutletSensor properties, unique_id, native values, and state."""
+        desc_map = {d.key: d for d in OUTLET_SENSOR_TYPES}
+
+        sensor_power = UnifiOutletSensor(
+            coordinator=mock_coordinator,
+            description=desc_map["power"],
+            site_id="site1",
+            device_id="pdu1",
+            outlet_index=1,
+            outlet_name="Main Server",
+        )
+        assert sensor_power.unique_id == "site1_pdu1_outlet_1_power"
+        assert sensor_power.native_value == 150.0
+        assert sensor_power.available is True
+        assert sensor_power.extra_state_attributes == {
+            "index": 1,
+            "name": "Main Server",
+            "relay_state": True,
+        }
+
+        sensor_voltage = UnifiOutletSensor(
+            coordinator=mock_coordinator,
+            description=desc_map["voltage"],
+            site_id="site1",
+            device_id="pdu1",
+            outlet_index=1,
+            outlet_name="Main Server",
+        )
+        assert sensor_voltage.unique_id == "site1_pdu1_outlet_1_voltage"
+        assert sensor_voltage.native_value == 120.2
+
+        sensor_current = UnifiOutletSensor(
+            coordinator=mock_coordinator,
+            description=desc_map["current"],
+            site_id="site1",
+            device_id="pdu1",
+            outlet_index=1,
+            outlet_name="Main Server",
+        )
+        assert sensor_current.unique_id == "site1_pdu1_outlet_1_current"
+        assert sensor_current.native_value == 1.25
+
+        sensor_pf = UnifiOutletSensor(
+            coordinator=mock_coordinator,
+            description=desc_map["power_factor"],
+            site_id="site1",
+            device_id="pdu1",
+            outlet_index=1,
+            outlet_name="Main Server",
+        )
+        assert sensor_pf.unique_id == "site1_pdu1_outlet_1_power_factor"
+        assert sensor_pf.native_value == 0.98
+
+    def test_outlet_sensor_unavailable_when_outlet_missing(
+        self, mock_coordinator
+    ) -> None:
+        """Test UnifiOutletSensor unavailable when outlet is missing from data."""
+        desc_map = {d.key: d for d in OUTLET_SENSOR_TYPES}
+        sensor = UnifiOutletSensor(
+            coordinator=mock_coordinator,
+            description=desc_map["power"],
+            site_id="site1",
+            device_id="pdu1",
+            outlet_index=99,
+        )
+        assert sensor.available is False
+        assert sensor.native_value is None
+
+    def test_outlet_has_metering_helper(self) -> None:
+        """Test _outlet_has_metering helper detects caps bitmask and values."""
+        assert _outlet_has_metering({"outlet_caps": 3}) is True
+        assert _outlet_has_metering({"outlet_caps": 2}) is True
+        assert _outlet_has_metering({"outlet_caps": 1}) is False
+        assert _outlet_has_metering({"outlet_power": 10.0}) is True
+        assert _outlet_has_metering({"power": 10.0}) is True
+        assert _outlet_has_metering({"outlet_voltage": 120.0}) is True
+        assert _outlet_has_metering({"outlet_current": 1.0}) is True
+        assert _outlet_has_metering({"outlet_power_factor": 0.9}) is True
+        assert _outlet_has_metering({}) is False
+
+
+class TestUnifiAcPowerSensors:
+    """Tests for device-level AC power consumption and budget sensors."""
+
+    @pytest.fixture
+    def mock_coordinator(self) -> MagicMock:
+        """Create mock coordinator with PDU device data."""
+        coordinator = MagicMock()
+        coordinator.available = True
+        coordinator.last_update_success = True
+        coordinator.protect_client = None
+        coordinator.data = {
+            "sites": {"site1": {"id": "site1", "name": "Default"}},
+            "devices": {
+                "site1": {
+                    "pdu1": {
+                        "id": "pdu1",
+                        "name": "Server Room PDU",
+                        "status": "online",
+                        "state": "ONLINE",
+                        "ac_power_consumption": 245.5,
+                        "ac_power_budget": 1800.0,
+                        "features": [],
+                        "outlet_table": [],
+                    },
+                    "switch1": {
+                        "id": "switch1",
+                        "name": "Standard Switch",
+                        "status": "online",
+                        "state": "ONLINE",
+                        "features": ["switching"],
+                        "ports": [],
+                    },
+                }
+            },
+            "stats": {"site1": {"pdu1": {}, "switch1": {}}},
+            "clients": {},
+            "wifi": {},
+        }
+        coordinator.get_site = MagicMock(
+            return_value=coordinator.data["sites"]["site1"]
+        )
+        return coordinator
+
+    async def test_setup_creates_ac_power_sensors_only_when_data_present(
+        self, hass: HomeAssistant, mock_coordinator, mock_config_entry
+    ) -> None:
+        """Test AC power sensors created for PDU but skipped for switch."""
+        mock_config_entry.runtime_data.coordinator = mock_coordinator
+        added_entities: list = []
+
+        def add_entities(new_entities, **kwargs):
+            added_entities.extend(new_entities)
+
+        await async_setup_entry(hass, mock_config_entry, add_entities)
+
+        pdu_sensors = [
+            e
+            for e in added_entities
+            if isinstance(e, UnifiInsightsSensor) and e._device_id == "pdu1"
+        ]
+        pdu_keys = {e.entity_description.key for e in pdu_sensors}
+        assert "ac_power_consumption" in pdu_keys
+        assert "ac_power_budget" in pdu_keys
+
+        switch_sensors = [
+            e
+            for e in added_entities
+            if isinstance(e, UnifiInsightsSensor) and e._device_id == "switch1"
+        ]
+        switch_keys = {e.entity_description.key for e in switch_sensors}
+        assert "ac_power_consumption" not in switch_keys
+        assert "ac_power_budget" not in switch_keys
+
+    def test_ac_power_sensor_unique_ids_and_values(self, mock_coordinator) -> None:
+        """Test literal unique_ids and values for AC power sensors."""
+        desc_map = {d.key: d for d in SENSOR_TYPES}
+
+        sensor_consumption = UnifiInsightsSensor(
+            coordinator=mock_coordinator,
+            description=desc_map["ac_power_consumption"],
+            site_id="site1",
+            device_id="pdu1",
+        )
+        assert sensor_consumption.unique_id == "site1_pdu1_ac_power_consumption"
+        assert sensor_consumption.native_value == 245.5
+
+        sensor_budget = UnifiInsightsSensor(
+            coordinator=mock_coordinator,
+            description=desc_map["ac_power_budget"],
+            site_id="site1",
+            device_id="pdu1",
+        )
+        assert sensor_budget.unique_id == "site1_pdu1_ac_power_budget"
+        assert sensor_budget.native_value == 1800.0
+
+    def test_outlet_sensor_edge_cases(self, mock_coordinator) -> None:
+        """Test UnifiOutletSensor _find_outlet_data edge cases."""
+        desc_map = {d.key: d for d in OUTLET_SENSOR_TYPES}
+        sensor = UnifiOutletSensor(
+            coordinator=mock_coordinator,
+            description=desc_map["power"],
+            site_id="site1",
+            device_id="pdu1",
+            outlet_index=1,
+        )
+
+        # 1. Device missing
+        mock_coordinator.data["devices"] = {}
+        assert sensor._find_outlet_data() is None
+        assert sensor.extra_state_attributes is None
+
+        # 2. Outlet table with invalid entries and matching outlet_idx
+        mock_coordinator.data["devices"] = {
+            "site1": {
+                "pdu1": {
+                    "outlet_table": [
+                        "not_a_dict",
+                        {"index": "invalid"},
+                        {"outlet_idx": 1, "name": None, "relay_state": None},
+                    ]
+                }
+            }
+        }
+        outlet = sensor._find_outlet_data()
+        assert outlet is not None
+        assert sensor.extra_state_attributes == {"index": 1}

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -33,6 +33,8 @@ from custom_components.unifi_insights.switch import (
     PARALLEL_UPDATES,
     UnifiClientBlockSwitch,
     UnifiFirewallRuleSwitch,
+    UnifiOutletCycleSwitch,
+    UnifiOutletSwitch,
     UnifiPolicyBasedRouteSwitch,
     UnifiProtectHighFPSSwitch,
     UnifiProtectMicrophoneSwitch,
@@ -2972,3 +2974,398 @@ class TestUnifiWifiSwitchEdgeCases:
 
         wifi_data = switch._get_wifi_data()
         assert wifi_data == initial_wifi_data
+
+
+class TestUnifiOutletSwitch:
+    """Tests for UnifiOutletSwitch platform entity."""
+
+    @pytest.fixture
+    def mock_coordinator(self) -> MagicMock:
+        """Create mock coordinator with PDU device data."""
+        coordinator = MagicMock()
+        coordinator.available = True
+        coordinator.data = {
+            "devices": {
+                "site1": {
+                    "pdu1": {
+                        "id": "pdu1",
+                        "_id": "60a1b2c3d4e5f67890123456",
+                        "name": "Smart PDU",
+                        "status": "online",
+                        "state": "ONLINE",
+                        "outlet_table": [
+                            {
+                                "index": 1,
+                                "name": "Main Server",
+                                "relay_state": True,
+                                "cycle_enabled": True,
+                                "outlet_caps": 3,
+                                "outlet_voltage": 120.2,
+                                "outlet_current": 1.25,
+                                "outlet_power": 150.0,
+                                "outlet_power_factor": 0.98,
+                            },
+                            {
+                                "index": 2,
+                                "name": "Backup Server",
+                                "relay_state": False,
+                                "cycle_enabled": False,
+                                "outlet_caps": 3,
+                                "outlet_voltage": 120.1,
+                                "outlet_current": 0.0,
+                                "outlet_power": 0.0,
+                                "outlet_power_factor": 0.0,
+                            },
+                            {
+                                "index": 3,
+                                "name": "Modem",
+                                "relay_state": True,
+                                "cycle_enabled": None,
+                                "outlet_caps": 1,
+                            },
+                        ],
+                    }
+                }
+            },
+            "protect": {"cameras": {}, "lights": {}},
+            "wifi": {},
+            "firewall_rules": {},
+            "clients": {},
+        }
+        coordinator.network_client = MagicMock()
+        coordinator.network_client.devices = MagicMock()
+        coordinator.network_client.devices.set_outlet_state = AsyncMock(
+            return_value=True
+        )
+        coordinator.async_set_outlet_state = AsyncMock(return_value=True)
+        coordinator.async_request_refresh = AsyncMock()
+        return coordinator
+
+    @pytest.mark.asyncio
+    async def test_async_setup_entry_creates_outlet_switches(
+        self, mock_coordinator
+    ) -> None:
+        mock_entry = MagicMock()
+        mock_entry.runtime_data.coordinator = mock_coordinator
+        entities = []
+
+        def async_add_entities(new_entities):
+            entities.extend(new_entities)
+
+        await async_setup_entry(
+            MagicMock(),
+            mock_entry,
+            async_add_entities,
+        )
+
+        outlet_switches = [e for e in entities if isinstance(e, UnifiOutletSwitch)]
+        cycle_switches = [e for e in entities if isinstance(e, UnifiOutletCycleSwitch)]
+
+        assert len(outlet_switches) == 3
+        # Outlets 1 and 2 have cycle_enabled not None; outlet 3 has cycle_enabled None
+        assert len(cycle_switches) == 2
+
+    def test_outlet_switch_properties(self, mock_coordinator) -> None:
+        """Test UnifiOutletSwitch properties and unique_id literal."""
+        outlet_data = mock_coordinator.data["devices"]["site1"]["pdu1"]["outlet_table"][
+            0
+        ]
+        switch = UnifiOutletSwitch(
+            coordinator=mock_coordinator,
+            site_id="site1",
+            device_id="pdu1",
+            outlet_index=1,
+            outlet_data=outlet_data,
+        )
+
+        assert switch.unique_id == "site1_pdu1_outlet_1"
+        assert switch.translation_key == "outlet"
+        assert switch.translation_placeholders == {"outlet_name": "Main Server"}
+        assert switch.is_on is True
+        assert switch.available is True
+        assert switch.icon == "mdi:power-socket-us"
+
+        attrs = switch.extra_state_attributes
+        assert attrs["index"] == 1
+        assert attrs["name"] == "Main Server"
+        assert attrs["relay_state"] is True
+        assert attrs["cycle_enabled"] is True
+        assert attrs["outlet_power"] == 150.0
+
+    @pytest.mark.asyncio
+    async def test_outlet_switch_turn_on(self, mock_coordinator) -> None:
+        """Test turning on the outlet switch."""
+        outlet_data = mock_coordinator.data["devices"]["site1"]["pdu1"]["outlet_table"][
+            1
+        ]
+        switch = UnifiOutletSwitch(
+            coordinator=mock_coordinator,
+            site_id="site1",
+            device_id="pdu1",
+            outlet_index=2,
+            outlet_data=outlet_data,
+        )
+        switch.async_write_ha_state = MagicMock()
+
+        await switch.async_turn_on()
+
+        mock_coordinator.async_set_outlet_state.assert_awaited_once_with(
+            "site1", "pdu1", 2, state=True
+        )
+        mock_coordinator.async_request_refresh.assert_awaited_once()
+        assert switch.is_on is True
+
+    @pytest.mark.asyncio
+    async def test_outlet_switch_turn_off(self, mock_coordinator) -> None:
+        """Test turning off the outlet switch."""
+        outlet_data = mock_coordinator.data["devices"]["site1"]["pdu1"]["outlet_table"][
+            0
+        ]
+        switch = UnifiOutletSwitch(
+            coordinator=mock_coordinator,
+            site_id="site1",
+            device_id="pdu1",
+            outlet_index=1,
+            outlet_data=outlet_data,
+        )
+        switch.async_write_ha_state = MagicMock()
+
+        await switch.async_turn_off()
+
+        mock_coordinator.async_set_outlet_state.assert_awaited_once_with(
+            "site1", "pdu1", 1, state=False
+        )
+        mock_coordinator.async_request_refresh.assert_awaited_once()
+        assert switch.is_on is False
+
+    @pytest.mark.asyncio
+    async def test_outlet_switch_turn_on_fallback(self, mock_coordinator) -> None:
+        """Test turning on uses fallback when coordinator method is not present."""
+        del mock_coordinator.async_set_outlet_state
+        outlet_data = mock_coordinator.data["devices"]["site1"]["pdu1"]["outlet_table"][
+            1
+        ]
+        switch = UnifiOutletSwitch(
+            coordinator=mock_coordinator,
+            site_id="site1",
+            device_id="pdu1",
+            outlet_index=2,
+            outlet_data=outlet_data,
+        )
+        switch.async_write_ha_state = MagicMock()
+
+        await switch.async_turn_on()
+
+        set_outlet = mock_coordinator.network_client.devices.set_outlet_state
+        set_outlet.assert_awaited_once_with(
+            "default", "pdu1", 2, state=True
+        )
+
+    def test_outlet_switch_unavailable_when_device_offline(
+        self, mock_coordinator
+    ) -> None:
+        """Test switch availability when device is offline."""
+        mock_coordinator.data["devices"]["site1"]["pdu1"]["state"] = "OFFLINE"
+        mock_coordinator.data["devices"]["site1"]["pdu1"]["status"] = "offline"
+
+        switch = UnifiOutletSwitch(
+            coordinator=mock_coordinator,
+            site_id="site1",
+            device_id="pdu1",
+            outlet_index=1,
+        )
+
+        assert switch.available is False
+
+
+class TestUnifiOutletCycleSwitch:
+    """Tests for UnifiOutletCycleSwitch entity."""
+
+    @pytest.fixture
+    def mock_coordinator(self) -> MagicMock:
+        """Create mock coordinator with PDU device data."""
+        coordinator = MagicMock()
+        coordinator.available = True
+        coordinator.data = {
+            "devices": {
+                "site1": {
+                    "pdu1": {
+                        "id": "pdu1",
+                        "_id": "60a1b2c3d4e5f67890123456",
+                        "name": "Smart PDU",
+                        "status": "online",
+                        "state": "ONLINE",
+                        "outlet_table": [
+                            {
+                                "index": 1,
+                                "name": "Main Server",
+                                "relay_state": True,
+                                "cycle_enabled": True,
+                                "outlet_caps": 3,
+                            },
+                            {
+                                "index": 2,
+                                "name": "Backup Server",
+                                "relay_state": False,
+                                "cycle_enabled": False,
+                                "outlet_caps": 3,
+                            },
+                        ],
+                    }
+                }
+            }
+        }
+        coordinator.network_client = MagicMock()
+        coordinator.network_client.devices = MagicMock()
+        coordinator.network_client.devices.set_outlet_state = AsyncMock(
+            return_value=True
+        )
+        coordinator.async_set_outlet_state = AsyncMock(return_value=True)
+        coordinator.async_request_refresh = AsyncMock()
+        return coordinator
+
+    def test_cycle_switch_properties(self, mock_coordinator) -> None:
+        """Test UnifiOutletCycleSwitch properties and unique_id literal."""
+        outlet_data = mock_coordinator.data["devices"]["site1"]["pdu1"]["outlet_table"][
+            0
+        ]
+        switch = UnifiOutletCycleSwitch(
+            coordinator=mock_coordinator,
+            site_id="site1",
+            device_id="pdu1",
+            outlet_index=1,
+            outlet_data=outlet_data,
+        )
+
+        assert switch.unique_id == "site1_pdu1_outlet_1_cycle_enabled"
+        assert switch.translation_key == "outlet_cycle_enabled"
+        assert switch.translation_placeholders == {"outlet_name": "Main Server"}
+        assert switch.entity_category == EntityCategory.CONFIG
+        assert switch.entity_registry_enabled_default is False
+        assert switch.is_on is True
+        assert switch.available is True
+
+    @pytest.mark.asyncio
+    async def test_cycle_switch_turn_on(self, mock_coordinator) -> None:
+        """Test turning on the power cycle switch."""
+        outlet_data = mock_coordinator.data["devices"]["site1"]["pdu1"]["outlet_table"][
+            1
+        ]
+        switch = UnifiOutletCycleSwitch(
+            coordinator=mock_coordinator,
+            site_id="site1",
+            device_id="pdu1",
+            outlet_index=2,
+            outlet_data=outlet_data,
+        )
+        switch.async_write_ha_state = MagicMock()
+
+        await switch.async_turn_on()
+
+        mock_coordinator.async_set_outlet_state.assert_awaited_once_with(
+            "site1", "pdu1", 2, state=False, cycle_enabled=True
+        )
+        mock_coordinator.async_request_refresh.assert_awaited_once()
+        assert switch.is_on is True
+
+    @pytest.mark.asyncio
+    async def test_cycle_switch_turn_off(self, mock_coordinator) -> None:
+        """Test turning off the power cycle switch."""
+        outlet_data = mock_coordinator.data["devices"]["site1"]["pdu1"]["outlet_table"][
+            0
+        ]
+        switch = UnifiOutletCycleSwitch(
+            coordinator=mock_coordinator,
+            site_id="site1",
+            device_id="pdu1",
+            outlet_index=1,
+            outlet_data=outlet_data,
+        )
+        switch.async_write_ha_state = MagicMock()
+
+        await switch.async_turn_off()
+
+        mock_coordinator.async_set_outlet_state.assert_awaited_once_with(
+            "site1", "pdu1", 1, state=True, cycle_enabled=False
+        )
+        mock_coordinator.async_request_refresh.assert_awaited_once()
+        assert switch.is_on is False
+
+    @pytest.mark.asyncio
+    async def test_cycle_switch_fallback(self, mock_coordinator) -> None:
+        """Test fallback when coordinator action is absent."""
+        del mock_coordinator.async_set_outlet_state
+        outlet_data = mock_coordinator.data["devices"]["site1"]["pdu1"]["outlet_table"][
+            0
+        ]
+        switch = UnifiOutletCycleSwitch(
+            coordinator=mock_coordinator,
+            site_id="site1",
+            device_id="pdu1",
+            outlet_index=1,
+            outlet_data=outlet_data,
+        )
+        switch.async_write_ha_state = MagicMock()
+
+        await switch.async_turn_off()
+
+        set_outlet = mock_coordinator.network_client.devices.set_outlet_state
+        set_outlet.assert_awaited_once_with(
+            "default", "pdu1", 1, state=True, cycle_enabled=False
+        )
+
+    def test_outlet_switch_edge_cases(self, mock_coordinator) -> None:
+        """Test outlet switch edge cases for complete branch coverage."""
+        # 1. Device data missing or not dict
+        mock_coordinator.data["devices"] = {}
+        switch = UnifiOutletSwitch(
+            coordinator=mock_coordinator,
+            site_id="site1",
+            device_id="pdu1",
+            outlet_index=1,
+            outlet_data={"relay_state": True},
+        )
+        assert switch._get_outlet_data() is None
+        assert switch.is_on is True
+        assert switch.available is False
+
+        # 2. Outlet table with invalid entries
+        mock_coordinator.data["devices"] = {
+            "site1": {
+                "pdu1": {
+                    "outlet_table": [
+                        "not_a_dict",
+                        {"index": "invalid"},
+                        {"outlet_idx": 2},
+                    ],
+                    "state": "ONLINE",
+                    "status": "online",
+                }
+            }
+        }
+        assert switch._get_outlet_data() is None
+        switch._update_local_state(relay_state=False)
+
+        # 3. Cycle switch with missing/offline data
+        cycle_switch = UnifiOutletCycleSwitch(
+            coordinator=mock_coordinator,
+            site_id="site1",
+            device_id="pdu1",
+            outlet_index=1,
+            outlet_data={"cycle_enabled": True},
+        )
+        assert cycle_switch._get_outlet_data() is None
+        assert cycle_switch.is_on is True
+        assert cycle_switch.available is False
+
+        # 4. Cycle switch update local state
+        mock_coordinator.data["devices"]["site1"]["pdu1"]["outlet_table"] = [
+            {"index": 1, "cycle_enabled": False}
+        ]
+        cycle_switch._update_local_state(cycle_enabled=True)
+        assert (
+            mock_coordinator.data["devices"]["site1"]["pdu1"]["outlet_table"][0][
+                "cycle_enabled"
+            ]
+            is True
+        )

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -3039,6 +3039,7 @@ class TestUnifiOutletSwitch:
         )
         coordinator.async_set_outlet_state = AsyncMock(return_value=True)
         coordinator.async_request_refresh = AsyncMock()
+        coordinator.resolve_legacy_site_name = MagicMock(return_value="default")
         return coordinator
 
     @pytest.mark.asyncio
@@ -3158,7 +3159,11 @@ class TestUnifiOutletSwitch:
 
         set_outlet = mock_coordinator.network_client.devices.set_outlet_state
         set_outlet.assert_awaited_once_with(
-            "default", "pdu1", 2, state=True
+            "default",
+            "pdu1",
+            2,
+            state=True,
+            current_device=mock_coordinator.data["devices"]["site1"]["pdu1"],
         )
 
     def test_outlet_switch_unavailable_when_device_offline(
@@ -3222,6 +3227,7 @@ class TestUnifiOutletCycleSwitch:
         )
         coordinator.async_set_outlet_state = AsyncMock(return_value=True)
         coordinator.async_request_refresh = AsyncMock()
+        coordinator.resolve_legacy_site_name = MagicMock(return_value="default")
         return coordinator
 
     def test_cycle_switch_properties(self, mock_coordinator) -> None:
@@ -3311,7 +3317,40 @@ class TestUnifiOutletCycleSwitch:
 
         set_outlet = mock_coordinator.network_client.devices.set_outlet_state
         set_outlet.assert_awaited_once_with(
-            "default", "pdu1", 1, state=True, cycle_enabled=False
+            "default",
+            "pdu1",
+            1,
+            state=True,
+            cycle_enabled=False,
+            current_device=mock_coordinator.data["devices"]["site1"]["pdu1"],
+        )
+
+    @pytest.mark.asyncio
+    async def test_cycle_switch_does_not_default_relay_on(
+        self, mock_coordinator
+    ) -> None:
+        """Test toggling power cycling never energizes an unknown relay.
+
+        set_outlet_state always writes relay_state into the override, so an
+        outlet whose reported data carries no relay_state must be treated as
+        OFF. Defaulting to ON would switch on a load the user did not ask for.
+        """
+        mock_coordinator.data["devices"]["site1"]["pdu1"]["outlet_table"] = [
+            {"index": 1, "name": "Main Server", "cycle_enabled": False}
+        ]
+        switch = UnifiOutletCycleSwitch(
+            coordinator=mock_coordinator,
+            site_id="site1",
+            device_id="pdu1",
+            outlet_index=1,
+            outlet_data={"index": 1, "cycle_enabled": False},
+        )
+        switch.async_write_ha_state = MagicMock()
+
+        await switch.async_turn_on()
+
+        mock_coordinator.async_set_outlet_state.assert_awaited_once_with(
+            "site1", "pdu1", 1, state=False, cycle_enabled=True
         )
 
     def test_outlet_switch_edge_cases(self, mock_coordinator) -> None:

--- a/tests/test_vendored_api.py
+++ b/tests/test_vendored_api.py
@@ -10,7 +10,10 @@ import pytest
 
 from custom_components.unifi_insights.api import ApiKeyAuth, ConnectionType
 from custom_components.unifi_insights.api.const import ENDPOINT_TRAFFIC_ROUTES
-from custom_components.unifi_insights.api.exceptions import UniFiResponseError
+from custom_components.unifi_insights.api.exceptions import (
+    UniFiResponseError,
+    UniFiValidationError,
+)
 from custom_components.unifi_insights.api.network import (
     PolicyBasedRoute,
     UniFiNetworkClient,
@@ -492,32 +495,34 @@ async def test_set_outlet_state_existing_override() -> None:
         base_url="https://192.168.1.1",
         connection_type=ConnectionType.LOCAL,
     )
-    client._get = AsyncMock(
-        return_value={
-            "data": [
-                {
-                    "_id": "60a1b2c3d4e5f67890123456",
-                    "outlet_overrides": [
-                        {
-                            "index": 1,
-                            "relay_state": True,
-                            "cycle_enabled": True,
-                        },
-                        {
-                            "index": 2,
-                            "relay_state": False,
-                        },
-                    ],
-                }
-            ]
-        }
-    )
+    client._get = AsyncMock()
     client._put = AsyncMock(return_value={"data": []})
 
     result = await client.devices.set_outlet_state(
-        "default", "60a1b2c3d4e5f67890123456", 1, state=False, cycle_enabled=False
+        "default",
+        "60a1b2c3d4e5f67890123456",
+        1,
+        state=False,
+        cycle_enabled=False,
+        current_device={
+            "_id": "60a1b2c3d4e5f67890123456",
+            "outlet_overrides": [
+                {
+                    "index": 1,
+                    "relay_state": True,
+                    "cycle_enabled": True,
+                },
+                {
+                    "index": 2,
+                    "relay_state": False,
+                },
+            ],
+        },
     )
     assert result is True
+
+    # The singular rest/device route is write-only on UniFi OS: never GET it.
+    client._get.assert_not_awaited()
     client._put.assert_awaited_once_with(
         "/proxy/network/api/s/default/rest/device/60a1b2c3d4e5f67890123456",
         json_data={
@@ -543,30 +548,32 @@ async def test_set_outlet_state_new_override() -> None:
         base_url="https://192.168.1.1",
         connection_type=ConnectionType.LOCAL,
     )
-    client._get = AsyncMock(
-        return_value={
-            "data": [
-                {
-                    "_id": "60a1b2c3d4e5f67890123456",
-                    "outlet_overrides": [],
-                }
-            ]
-        }
-    )
     client._put = AsyncMock(return_value={"data": []})
 
     result = await client.devices.set_outlet_state(
-        "default", "60a1b2c3d4e5f67890123456", 3, state=True
+        "default",
+        "60a1b2c3d4e5f67890123456",
+        3,
+        state=True,
+        current_device={
+            "_id": "60a1b2c3d4e5f67890123456",
+            "outlet_overrides": [
+                {"index": 1, "relay_state": True},
+                {"index": 2, "relay_state": False},
+            ],
+        },
     )
     assert result is True
     client._put.assert_awaited_once_with(
         "/proxy/network/api/s/default/rest/device/60a1b2c3d4e5f67890123456",
         json_data={
             "outlet_overrides": [
+                {"index": 1, "relay_state": True},
+                {"index": 2, "relay_state": False},
                 {
                     "index": 3,
                     "relay_state": True,
-                }
+                },
             ]
         },
     )
@@ -584,40 +591,37 @@ async def test_set_outlet_state_seeds_overrides_from_outlet_table() -> None:
         base_url="https://192.168.1.1",
         connection_type=ConnectionType.LOCAL,
     )
-    client._get = AsyncMock(
-        return_value={
-            "data": [
-                {
-                    "_id": "60a1b2c3d4e5f67890123456",
-                    "outlet_overrides": [],
-                    "outlet_table": [
-                        {
-                            "index": 1,
-                            "name": "Router",
-                            "relay_state": True,
-                            "cycle_enabled": False,
-                        },
-                        {
-                            "index": 2,
-                            "name": "NAS",
-                            "relay_state": True,
-                            "cycle_enabled": False,
-                        },
-                        {
-                            "index": 3,
-                            "name": "Spare",
-                            "relay_state": False,
-                            "cycle_enabled": False,
-                        },
-                    ],
-                }
-            ]
-        }
-    )
     client._put = AsyncMock(return_value={"data": []})
 
     result = await client.devices.set_outlet_state(
-        "default", "60a1b2c3d4e5f67890123456", 2, state=False
+        "default",
+        "60a1b2c3d4e5f67890123456",
+        2,
+        state=False,
+        current_device={
+            "_id": "60a1b2c3d4e5f67890123456",
+            "outlet_overrides": [],
+            "outlet_table": [
+                {
+                    "index": 1,
+                    "name": "Router",
+                    "relay_state": True,
+                    "cycle_enabled": False,
+                },
+                {
+                    "index": 2,
+                    "name": "NAS",
+                    "relay_state": True,
+                    "cycle_enabled": False,
+                },
+                {
+                    "index": 3,
+                    "name": "Spare",
+                    "relay_state": False,
+                    "cycle_enabled": False,
+                },
+            ],
+        },
     )
     assert result is True
 
@@ -634,26 +638,52 @@ async def test_set_outlet_state_seeds_overrides_from_outlet_table() -> None:
     assert by_index[1]["name"] == "Router"
 
 
-async def test_set_outlet_state_no_outlet_table_appends_single_override() -> None:
-    """Test set_outlet_state still appends when no outlet_table is available."""
+async def test_set_outlet_state_rejects_unseedable_write() -> None:
+    """Test set_outlet_state refuses to write a partial override array.
+
+    Without existing overrides or an outlet_table to seed from, the sibling
+    outlet states are unknown. The controller treats outlet_overrides as the
+    complete desired state, so a single-entry write would reset every other
+    outlet on the device. Refuse the write instead.
+    """
     client = UniFiNetworkClient(
         auth=ApiKeyAuth(api_key="test-key"),
         base_url="https://192.168.1.1",
         connection_type=ConnectionType.LOCAL,
     )
-    client._get = AsyncMock(
-        return_value={"data": [{"_id": "60a1b2c3d4e5f67890123456"}]}
-    )
+    client._get = AsyncMock()
     client._put = AsyncMock(return_value={"data": []})
 
-    result = await client.devices.set_outlet_state(
-        "default", "60a1b2c3d4e5f67890123456", 4, state=True
+    with pytest.raises(UniFiValidationError):
+        await client.devices.set_outlet_state(
+            "default",
+            "60a1b2c3d4e5f67890123456",
+            4,
+            state=True,
+            current_device={"_id": "60a1b2c3d4e5f67890123456"},
+        )
+
+    client._put.assert_not_awaited()
+    client._get.assert_not_awaited()
+
+
+async def test_set_outlet_state_rejects_missing_snapshot() -> None:
+    """Test set_outlet_state refuses to write without a device snapshot."""
+    client = UniFiNetworkClient(
+        auth=ApiKeyAuth(api_key="test-key"),
+        base_url="https://192.168.1.1",
+        connection_type=ConnectionType.LOCAL,
     )
-    assert result is True
-    client._put.assert_awaited_once_with(
-        "/proxy/network/api/s/default/rest/device/60a1b2c3d4e5f67890123456",
-        json_data={"outlet_overrides": [{"index": 4, "relay_state": True}]},
-    )
+    client._get = AsyncMock()
+    client._put = AsyncMock(return_value={"data": []})
+
+    with pytest.raises(UniFiValidationError):
+        await client.devices.set_outlet_state(
+            "default", "60a1b2c3d4e5f67890123456", 4, state=True
+        )
+
+    client._put.assert_not_awaited()
+    client._get.assert_not_awaited()
 
 
 async def test_wifi_update_uses_put_with_existing_payload() -> None:

--- a/tests/test_vendored_api.py
+++ b/tests/test_vendored_api.py
@@ -15,6 +15,7 @@ from custom_components.unifi_insights.api.network import (
     PolicyBasedRoute,
     UniFiNetworkClient,
     VpnClient,
+    parse_outlet_metrics,
 )
 from custom_components.unifi_insights.api.protect import UniFiProtectClient
 
@@ -395,6 +396,264 @@ async def test_get_port_metrics_returns_defaults_for_empty_payload() -> None:
     assert metrics.poe_total_w is None
     assert metrics.poe_ports == {}
     assert metrics.port_bytes == {}
+
+
+async def test_parse_outlet_metrics() -> None:
+    """Test parse_outlet_metrics correctly parses outlet table and power totals."""
+    raw = {
+        "outlet_ac_power_consumption": "125.5",
+        "outlet_ac_power_budget": "1800",
+        "outlet_table": [
+            {
+                "index": 1,
+                "name": "Outlet 1",
+                "relay_state": True,
+                "cycle_enabled": True,
+                "outlet_caps": 3,
+                "outlet_voltage": "120.5",
+                "outlet_current": "1.04",
+                "outlet_power": "125.5",
+                "outlet_power_factor": "0.99",
+            },
+            {
+                "index": 2,
+                "name": "Outlet 2",
+                "relay_state": False,
+                "cycle_enabled": False,
+                "outlet_caps": 1,
+                "outlet_voltage": None,
+                "outlet_current": None,
+                "outlet_power": None,
+                "outlet_power_factor": None,
+            },
+        ],
+    }
+    metrics = parse_outlet_metrics(raw)
+    assert metrics.ac_power_consumption == 125.5
+    assert metrics.ac_power_budget == 1800.0
+    assert len(metrics.outlets) == 2
+    assert metrics.outlets[0].index == 1
+    assert metrics.outlets[0].name == "Outlet 1"
+    assert metrics.outlets[0].relay_state is True
+    assert metrics.outlets[0].cycle_enabled is True
+    assert metrics.outlets[0].outlet_caps == 3
+    assert metrics.outlets[0].outlet_voltage == 120.5
+    assert metrics.outlets[0].outlet_current == 1.04
+    assert metrics.outlets[0].outlet_power == 125.5
+    assert metrics.outlets[0].outlet_power_factor == 0.99
+
+    assert metrics.outlets[1].index == 2
+    assert metrics.outlets[1].relay_state is False
+    assert metrics.outlets[1].cycle_enabled is False
+    assert metrics.outlets[1].outlet_power is None
+
+
+async def test_parse_outlet_metrics_empty() -> None:
+    """Test parse_outlet_metrics returns empty model for empty or non-dict input."""
+    assert parse_outlet_metrics({}).outlets == []
+    assert parse_outlet_metrics(None).outlets == []  # type: ignore[arg-type]
+
+
+async def test_get_outlet_metrics() -> None:
+    """Test get_outlet_metrics fetches legacy stats and parses outlet metrics."""
+    client = UniFiNetworkClient(
+        auth=ApiKeyAuth(api_key="test-key"),
+        base_url="https://192.168.1.1",
+        connection_type=ConnectionType.LOCAL,
+    )
+    client._get = AsyncMock(
+        return_value={
+            "data": [
+                {
+                    "outlet_ac_power_consumption": "50.0",
+                    "outlet_table": [
+                        {
+                            "index": 1,
+                            "name": "Port A",
+                            "relay_state": True,
+                            "outlet_power": "50.0",
+                        }
+                    ],
+                }
+            ]
+        }
+    )
+    metrics = await client.devices.get_outlet_metrics("default", "00:11:22:33:44:55")
+    assert metrics.ac_power_consumption == 50.0
+    assert len(metrics.outlets) == 1
+    assert metrics.outlets[0].name == "Port A"
+    assert metrics.outlets[0].relay_state is True
+
+
+async def test_set_outlet_state_existing_override() -> None:
+    """Test set_outlet_state updates an existing override."""
+    client = UniFiNetworkClient(
+        auth=ApiKeyAuth(api_key="test-key"),
+        base_url="https://192.168.1.1",
+        connection_type=ConnectionType.LOCAL,
+    )
+    client._get = AsyncMock(
+        return_value={
+            "data": [
+                {
+                    "_id": "60a1b2c3d4e5f67890123456",
+                    "outlet_overrides": [
+                        {
+                            "index": 1,
+                            "relay_state": True,
+                            "cycle_enabled": True,
+                        },
+                        {
+                            "index": 2,
+                            "relay_state": False,
+                        },
+                    ],
+                }
+            ]
+        }
+    )
+    client._put = AsyncMock(return_value={"data": []})
+
+    result = await client.devices.set_outlet_state(
+        "default", "60a1b2c3d4e5f67890123456", 1, state=False, cycle_enabled=False
+    )
+    assert result is True
+    client._put.assert_awaited_once_with(
+        "/proxy/network/api/s/default/rest/device/60a1b2c3d4e5f67890123456",
+        json_data={
+            "outlet_overrides": [
+                {
+                    "index": 1,
+                    "relay_state": False,
+                    "cycle_enabled": False,
+                },
+                {
+                    "index": 2,
+                    "relay_state": False,
+                },
+            ]
+        },
+    )
+
+
+async def test_set_outlet_state_new_override() -> None:
+    """Test set_outlet_state appends a new override when none exists for index."""
+    client = UniFiNetworkClient(
+        auth=ApiKeyAuth(api_key="test-key"),
+        base_url="https://192.168.1.1",
+        connection_type=ConnectionType.LOCAL,
+    )
+    client._get = AsyncMock(
+        return_value={
+            "data": [
+                {
+                    "_id": "60a1b2c3d4e5f67890123456",
+                    "outlet_overrides": [],
+                }
+            ]
+        }
+    )
+    client._put = AsyncMock(return_value={"data": []})
+
+    result = await client.devices.set_outlet_state(
+        "default", "60a1b2c3d4e5f67890123456", 3, state=True
+    )
+    assert result is True
+    client._put.assert_awaited_once_with(
+        "/proxy/network/api/s/default/rest/device/60a1b2c3d4e5f67890123456",
+        json_data={
+            "outlet_overrides": [
+                {
+                    "index": 3,
+                    "relay_state": True,
+                }
+            ]
+        },
+    )
+
+
+async def test_set_outlet_state_seeds_overrides_from_outlet_table() -> None:
+    """Test set_outlet_state seeds a full override array from outlet_table.
+
+    A factory-fresh PDU reports an empty outlet_overrides array. Because the
+    controller treats that array as the complete desired state, writing only the
+    changed outlet would reset every other outlet to its default.
+    """
+    client = UniFiNetworkClient(
+        auth=ApiKeyAuth(api_key="test-key"),
+        base_url="https://192.168.1.1",
+        connection_type=ConnectionType.LOCAL,
+    )
+    client._get = AsyncMock(
+        return_value={
+            "data": [
+                {
+                    "_id": "60a1b2c3d4e5f67890123456",
+                    "outlet_overrides": [],
+                    "outlet_table": [
+                        {
+                            "index": 1,
+                            "name": "Router",
+                            "relay_state": True,
+                            "cycle_enabled": False,
+                        },
+                        {
+                            "index": 2,
+                            "name": "NAS",
+                            "relay_state": True,
+                            "cycle_enabled": False,
+                        },
+                        {
+                            "index": 3,
+                            "name": "Spare",
+                            "relay_state": False,
+                            "cycle_enabled": False,
+                        },
+                    ],
+                }
+            ]
+        }
+    )
+    client._put = AsyncMock(return_value={"data": []})
+
+    result = await client.devices.set_outlet_state(
+        "default", "60a1b2c3d4e5f67890123456", 2, state=False
+    )
+    assert result is True
+
+    payload = client._put.await_args.kwargs["json_data"]["outlet_overrides"]
+
+    # Every outlet survives the write, not just the one that changed.
+    assert [entry["index"] for entry in payload] == [1, 2, 3]
+
+    # Only the target outlet flipped; siblings keep their sensed state.
+    by_index = {entry["index"]: entry for entry in payload}
+    assert by_index[2]["relay_state"] is False
+    assert by_index[1]["relay_state"] is True
+    assert by_index[3]["relay_state"] is False
+    assert by_index[1]["name"] == "Router"
+
+
+async def test_set_outlet_state_no_outlet_table_appends_single_override() -> None:
+    """Test set_outlet_state still appends when no outlet_table is available."""
+    client = UniFiNetworkClient(
+        auth=ApiKeyAuth(api_key="test-key"),
+        base_url="https://192.168.1.1",
+        connection_type=ConnectionType.LOCAL,
+    )
+    client._get = AsyncMock(
+        return_value={"data": [{"_id": "60a1b2c3d4e5f67890123456"}]}
+    )
+    client._put = AsyncMock(return_value={"data": []})
+
+    result = await client.devices.set_outlet_state(
+        "default", "60a1b2c3d4e5f67890123456", 4, state=True
+    )
+    assert result is True
+    client._put.assert_awaited_once_with(
+        "/proxy/network/api/s/default/rest/device/60a1b2c3d4e5f67890123456",
+        json_data={"outlet_overrides": [{"index": 4, "relay_state": True}]},
+    )
 
 
 async def test_wifi_update_uses_put_with_existing_payload() -> None:


### PR DESCRIPTION
## Description

Adds full support for UniFi SmartPower Power Distribution Units (PDUs) and power strips (e.g. USP-PDU-Pro and USP-Strip).

### What this adds:
- **Per-outlet relay switches** (`UnifiOutletSwitch`) to turn individual outlets on/off.
- **Per-outlet cycle-enabled switches** (`UnifiOutletCycleSwitch`) for modem/gateway power cycle configuration (disabled by default to keep default entity counts manageable).
- **Per-outlet metering sensors** (`UnifiOutletSensor`) reporting Voltage (`V`), Current (`A`), Power (`W`), and Power Factor on outlets that provide metering capabilities (`caps: 3`). Unmetered outlets (e.g., USB ports with `caps: 1`) produce no metering sensors.
- **Device-level power total sensors** for AC Power Consumption and AC Power Budget.

### Design and Architecture Decisions:
- **Zero additional polling overhead:** Outlet state and AC totals are merged from the existing legacy device data (`/stat/device`) that `UnifiDeviceCoordinator` already retrieves once per site poll. Devices lacking an `outlet_table` produce no entities.
- **Cached read-modify-write:** Controller writes to `outlet_overrides` require the full array of desired outlet states. Sourcing the current device state from the coordinator's cached data avoids an extra GET against `/rest/device/{id}` (which is write-only on UniFi OS and returns 404 on GET) while preserving all untouched sibling outlets.
- **Stable Unique IDs:** Unique IDs use `{site_id}_{device_id}_outlet_{index}` (sensors append the metric key; cycle switch appends `_cycle_enabled`). Index-based unique IDs ensure renaming outlets in UniFi does not orphan entities or break automations.
- **Translations:** Uses `translation_key` and placeholders for switch and sensor naming across `strings.json` and `translations/en.json` (100% key parity).

## Type of Change

- [ ] 🐛 **Bug fix** (non-breaking change fixing an issue)
- [x] ✨ **New feature** (non-breaking change adding functionality)
- [ ] 💥 **Breaking change** (fix or feature causing existing functionality/automations to break)
- [ ] ♻️ **Refactoring** (code organization, no functional change)
- [x] 📝 **Documentation** (documentation updates only)
- [x] 🧪 **Tests** (adding or improving test coverage)
- [ ] 🔧 **Maintenance / Chore** (dependency updates, tool config, CI)

## Architecture & Home Assistant Quality Scale Checklist

- [x] **Data Flow**: Entities read solely from `coordinator.data` via `UnifiFacadeCoordinator`.
- [x] **API Encapsulation**: Actions route through coordinator methods and vendored API client models.
- [x] **Base Entities**: Inherits from `UnifiInsightsEntity` with `_attr_has_entity_name = True`.
- [x] **Parallel Updates**: `PARALLEL_UPDATES = 1` maintained for switches and `PARALLEL_UPDATES = 0` for sensors.
- [x] **Error Handling**: API errors wrapped into user-friendly `HomeAssistantError`.
- [x] **Unique IDs & Device Info**: Attached to the existing PDU `DeviceInfo` (single device in registry).
- [x] **Translations**: Uses translation keys (`outlet`, `outlet_cycle_enabled`, `ac_power_consumption`, `ac_power_budget`, etc.) with placeholders.

## Validation Checklist

- [x] `ruff check` and `ruff format --check` passed with 0 errors on modified files.
- [x] Line length limit (88 characters) respected across all added code.
- [x] `mypy custom_components/unifi_insights` passed with 0 errors across all 27 files.
- [x] `pytest` passed with ≥ 90% branch coverage (1,269 passed, 90.36% coverage).
- [x] `CHANGELOG.md` updated under `[Unreleased]` Added.

## Live Hardware Verification

Verified on physical hardware (**USP-PDU-Pro**, 20 outlets):
1. **Device Registry:** All 121 entities (40 switches, 78 sensors) attached to the single existing PDU device entry. Zero duplicate or fragmented devices.
2. **Relay Control:** Tested toggling an idle outlet on/off; verified physical relay switching and real-time line voltage jumping from `0.0 V` to `123.98 V` and back to `0.0 V`.
3. **Sibling Outlets Intact:** Polled the controller's 21-element `outlet_overrides` array before, during, and after the write; confirmed all 20 other outlets retained their exact names, states, and power-cycle configs with zero disturbance.
4. **Metering & USB Ports:** Verified unmetered USB ports (1–4) generated no sensors, while metered AC outlets (5–20) generated full 4-sensor suites with live active load telemetry matching actual equipment.
5. **Device Totals:** Verified `ac_power_consumption` (`300.4 W`) and `ac_power_budget` (`1875 W`) matched controller telemetry and the UniFi UI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for UniFi Power Distribution Units and SmartPower strips.
  - Added per-outlet relay switches and optional automatic power-cycle controls.
  - Added per-outlet power, voltage, current and power-factor sensors.
  - Added device-level AC power consumption and power budget sensors.
  - Added support for preserving outlet states when updating power-cycle settings.
- **Documentation**
  - Updated the unreleased changelog with the new PDU and SmartPower capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->