### PR TITLE
fix(device_tracker): only remove trackers the config no longer wants

### DIFF
--- a/custom_components/unifi_insights/device_tracker.py
+++ b/custom_components/unifi_insights/device_tracker.py
@@ -51,14 +51,15 @@ def _client_should_be_tracked(
     return track_wifi or track_wired
 
 
-def _connected_clients_to_track(
+def _partition_connected_clients(
     coordinator: UnifiFacadeCoordinator,
     *,
     track_wifi: bool,
     track_wired: bool,
-) -> dict[str, str]:
-    """Map MAC (lowercase) -> site_id for connected clients that should track."""
+) -> tuple[dict[str, str], set[str]]:
+    """Split connected clients into tracked (MAC -> site_id) and untracked MACs."""
     wanted: dict[str, str] = {}
+    untracked: set[str] = set()
     for site_id, clients in coordinator.data.get("clients", {}).items():
         if not isinstance(clients, dict):
             continue
@@ -70,6 +71,21 @@ def _connected_clients_to_track(
                 client_data, track_wifi=track_wifi, track_wired=track_wired
             ):
                 wanted[mac.lower()] = site_id
+            else:
+                untracked.add(mac.lower())
+    return wanted, untracked
+
+
+def _connected_clients_to_track(
+    coordinator: UnifiFacadeCoordinator,
+    *,
+    track_wifi: bool,
+    track_wired: bool,
+) -> dict[str, str]:
+    """Map MAC (lowercase) -> site_id for connected clients that should track."""
+    wanted, _ = _partition_connected_clients(
+        coordinator, track_wifi=track_wifi, track_wired=track_wired
+    )
     return wanted
 
 
@@ -89,30 +105,47 @@ async def async_setup_entry(
 
     _LOGGER.debug("Client tracking - WiFi: %s, Wired: %s", track_wifi, track_wired)
 
-    # Reconcile the entity registry with the current options/connected clients.
-    # This runs on every setup (including option-change reloads), so disabling a
-    # client type removes its trackers and only currently connected clients of
-    # the enabled types remain. Without this, toggling options would leave stale
-    # "unavailable" trackers behind.
-    wanted = _connected_clients_to_track(
-        coordinator, track_wifi=track_wifi, track_wired=track_wired
-    )
-    wanted_unique_ids = {f"{DOMAIN}_{mac}" for mac in wanted}
+    # Reconcile the entity registry with the current options. This runs on every
+    # setup, including option-change reloads.
+    #
+    # Only remove a tracker when the configuration says it is unwanted: either
+    # tracking is off entirely, or the client is currently connected with a type
+    # that is no longer tracked.
+    #
+    # A client merely missing from the connected-client snapshot is NOT evidence
+    # that its tracker should go -- it may be powered off or roaming, or the poll
+    # behind `coordinator.data` may have failed or not run yet. Removing the
+    # registry entry is permanent and destroys the user's name, area, and
+    # entity_id customisation, and reporting `not_home` for an absent device is
+    # the entire purpose of a device tracker.
     registry = er.async_get(hass)
-    for reg_entry in er.async_entries_for_config_entry(registry, entry.entry_id):
-        if (
-            reg_entry.domain == "device_tracker"
-            and reg_entry.platform == DOMAIN
-            and reg_entry.unique_id not in wanted_unique_ids
-        ):
-            _LOGGER.debug(
-                "Removing client tracker %s (no longer tracked)", reg_entry.entity_id
-            )
-            registry.async_remove(reg_entry.entity_id)
+    client_trackers = [
+        reg_entry
+        for reg_entry in er.async_entries_for_config_entry(registry, entry.entry_id)
+        if reg_entry.domain == "device_tracker" and reg_entry.platform == DOMAIN
+    ]
 
     if not track_wifi and not track_wired:
+        for reg_entry in client_trackers:
+            _LOGGER.debug(
+                "Removing client tracker %s (client tracking disabled)",
+                reg_entry.entity_id,
+            )
+            registry.async_remove(reg_entry.entity_id)
         _LOGGER.debug("Client tracking disabled - no client trackers created")
         return
+
+    _, untracked_macs = _partition_connected_clients(
+        coordinator, track_wifi=track_wifi, track_wired=track_wired
+    )
+    untracked_unique_ids = {f"{DOMAIN}_{mac}" for mac in untracked_macs}
+    for reg_entry in client_trackers:
+        if reg_entry.unique_id in untracked_unique_ids:
+            _LOGGER.debug(
+                "Removing client tracker %s (client type no longer tracked)",
+                reg_entry.entity_id,
+            )
+            registry.async_remove(reg_entry.entity_id)
 
     # Per-setup dedup set (recreated on every reload so re-enabling re-adds
     # entities); MAC is globally unique so it is used as the key.

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-from homeassistant.components.device_tracker import SourceType
 import pytest
+from homeassistant.components.device_tracker import SourceType
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components.unifi_insights.const import DOMAIN
 from custom_components.unifi_insights.device_tracker import (
     PARALLEL_UPDATES,
     UnifiClientTracker,
@@ -811,3 +813,124 @@ class TestUnifiClientTrackerEdgeCases:
         assert client_data is not None
         assert client_data["id"] == "valid_client"
         assert tracker.is_connected is True
+
+
+class TestRegistryReconciliation:
+    """Registry reconciliation on setup (upstream issue #116).
+
+    A tracker may only be deleted because the *configuration* no longer wants it,
+    never because the client is missing from the current snapshot. Deletion is
+    permanent and takes the user's name/area/entity_id customisation with it.
+    """
+
+    OFFLINE_MAC = "aa:bb:cc:dd:ee:01"
+    WIRED_MAC = "aa:bb:cc:dd:ee:02"
+    WIFI_MAC = "aa:bb:cc:dd:ee:03"
+
+    @pytest.fixture
+    def mock_coordinator(self) -> MagicMock:
+        """Create mock coordinator with an empty client snapshot."""
+        coordinator = MagicMock()
+        coordinator.data = {"clients": {"site1": {}}}
+        return coordinator
+
+    @staticmethod
+    def _entry(hass, coordinator: MagicMock, options: dict) -> MockConfigEntry:
+        """Build a config entry wired to the coordinator."""
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={"connection_type": "remote", "console_id": "c", "api_key": "k"},
+            options=options,
+            entry_id="tracker_reconcile_entry",
+        )
+        entry.add_to_hass(hass)
+        entry.runtime_data = MagicMock()
+        entry.runtime_data.coordinator = coordinator
+        return entry
+
+    @staticmethod
+    def _register(entity_registry, entry: MockConfigEntry, mac: str) -> str:
+        """Register an existing client tracker and return its entity_id."""
+        return entity_registry.async_get_or_create(
+            "device_tracker",
+            DOMAIN,
+            f"{DOMAIN}_{mac}",
+            config_entry=entry,
+            suggested_object_id=f"client_{mac.replace(':', '')}",
+        ).entity_id
+
+    @staticmethod
+    def _client(mac: str, client_type: str) -> dict:
+        """Build a connected-client payload."""
+        return {"id": mac, "mac": mac, "connected": True, "type": client_type}
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "data",
+        [
+            # Site polled fine, this client is simply not connected right now.
+            pytest.param({"clients": {"site1": {}}}, id="client_offline"),
+            # No sites at all: a poll that failed or has not run yet. This is the
+            # case that wiped every client tracker in issue #116.
+            pytest.param({"clients": {}}, id="poll_returned_nothing"),
+            pytest.param({}, id="coordinator_has_no_data"),
+        ],
+    )
+    async def test_absent_client_keeps_its_registry_entry(
+        self, hass, entity_registry, mock_coordinator, data
+    ) -> None:
+        """A client missing from the snapshot must not lose its registry entry."""
+        mock_coordinator.data = data
+
+        entry = self._entry(hass, mock_coordinator, {"track_wifi_clients": True})
+        entity_id = self._register(entity_registry, entry, self.OFFLINE_MAC)
+
+        await async_setup_entry(hass, entry, MagicMock())
+
+        assert entity_registry.async_get(entity_id) is not None
+
+    @pytest.mark.asyncio
+    async def test_connected_client_of_untracked_type_is_removed(
+        self, hass, entity_registry, mock_coordinator
+    ) -> None:
+        """A connected client whose type is no longer tracked is still removed."""
+        mock_coordinator.data["clients"]["site1"] = {
+            "c1": self._client(self.WIRED_MAC, "WIRED")
+        }
+
+        entry = self._entry(hass, mock_coordinator, {"track_wifi_clients": True})
+        entity_id = self._register(entity_registry, entry, self.WIRED_MAC)
+
+        await async_setup_entry(hass, entry, MagicMock())
+
+        assert entity_registry.async_get(entity_id) is None
+
+    @pytest.mark.asyncio
+    async def test_connected_tracked_client_is_kept(
+        self, hass, entity_registry, mock_coordinator
+    ) -> None:
+        """A connected client of a tracked type keeps its registry entry."""
+        mock_coordinator.data["clients"]["site1"] = {
+            "c1": self._client(self.WIFI_MAC, "WIRELESS")
+        }
+
+        entry = self._entry(hass, mock_coordinator, {"track_wifi_clients": True})
+        entity_id = self._register(entity_registry, entry, self.WIFI_MAC)
+
+        await async_setup_entry(hass, entry, MagicMock())
+
+        assert entity_registry.async_get(entity_id) is not None
+
+    @pytest.mark.asyncio
+    async def test_tracking_disabled_removes_all_trackers(
+        self, hass, entity_registry, mock_coordinator
+    ) -> None:
+        """Turning tracking off is a config decision, so it may remove everything."""
+        entry = self._entry(hass, mock_coordinator, {})
+        offline = self._register(entity_registry, entry, self.OFFLINE_MAC)
+        wifi = self._register(entity_registry, entry, self.WIFI_MAC)
+
+        await async_setup_entry(hass, entry, MagicMock())
+
+        assert entity_registry.async_get(offline) is None
+        assert entity_registry.async_get(wifi) is None

--- a/tests/test_device_tracker.py
+++ b/tests/test_device_tracker.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -15,6 +16,10 @@ from custom_components.unifi_insights.device_tracker import (
     _get_client_type,
     async_setup_entry,
 )
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import entity_registry as er
 
 
 class TestParallelUpdates:
@@ -823,9 +828,9 @@ class TestRegistryReconciliation:
     permanent and takes the user's name/area/entity_id customisation with it.
     """
 
-    OFFLINE_MAC = "aa:bb:cc:dd:ee:01"
-    WIRED_MAC = "aa:bb:cc:dd:ee:02"
-    WIFI_MAC = "aa:bb:cc:dd:ee:03"
+    OFFLINE_MAC: str = "aa:bb:cc:dd:ee:01"
+    WIRED_MAC: str = "aa:bb:cc:dd:ee:02"
+    WIFI_MAC: str = "aa:bb:cc:dd:ee:03"
 
     @pytest.fixture
     def mock_coordinator(self) -> MagicMock:
@@ -835,7 +840,9 @@ class TestRegistryReconciliation:
         return coordinator
 
     @staticmethod
-    def _entry(hass, coordinator: MagicMock, options: dict) -> MockConfigEntry:
+    def _entry(
+        hass: HomeAssistant, coordinator: MagicMock, options: dict[str, Any]
+    ) -> MockConfigEntry:
         """Build a config entry wired to the coordinator."""
         entry = MockConfigEntry(
             domain=DOMAIN,
@@ -849,7 +856,9 @@ class TestRegistryReconciliation:
         return entry
 
     @staticmethod
-    def _register(entity_registry, entry: MockConfigEntry, mac: str) -> str:
+    def _register(
+        entity_registry: er.EntityRegistry, entry: MockConfigEntry, mac: str
+    ) -> str:
         """Register an existing client tracker and return its entity_id."""
         return entity_registry.async_get_or_create(
             "device_tracker",
@@ -860,7 +869,7 @@ class TestRegistryReconciliation:
         ).entity_id
 
     @staticmethod
-    def _client(mac: str, client_type: str) -> dict:
+    def _client(mac: str, client_type: str) -> dict[str, Any]:
         """Build a connected-client payload."""
         return {"id": mac, "mac": mac, "connected": True, "type": client_type}
 
@@ -877,7 +886,11 @@ class TestRegistryReconciliation:
         ],
     )
     async def test_absent_client_keeps_its_registry_entry(
-        self, hass, entity_registry, mock_coordinator, data
+        self,
+        hass: HomeAssistant,
+        entity_registry: er.EntityRegistry,
+        mock_coordinator: MagicMock,
+        data: dict[str, Any],
     ) -> None:
         """A client missing from the snapshot must not lose its registry entry."""
         mock_coordinator.data = data
@@ -891,7 +904,10 @@ class TestRegistryReconciliation:
 
     @pytest.mark.asyncio
     async def test_connected_client_of_untracked_type_is_removed(
-        self, hass, entity_registry, mock_coordinator
+        self,
+        hass: HomeAssistant,
+        entity_registry: er.EntityRegistry,
+        mock_coordinator: MagicMock,
     ) -> None:
         """A connected client whose type is no longer tracked is still removed."""
         mock_coordinator.data["clients"]["site1"] = {
@@ -907,7 +923,10 @@ class TestRegistryReconciliation:
 
     @pytest.mark.asyncio
     async def test_connected_tracked_client_is_kept(
-        self, hass, entity_registry, mock_coordinator
+        self,
+        hass: HomeAssistant,
+        entity_registry: er.EntityRegistry,
+        mock_coordinator: MagicMock,
     ) -> None:
         """A connected client of a tracked type keeps its registry entry."""
         mock_coordinator.data["clients"]["site1"] = {
@@ -923,7 +942,10 @@ class TestRegistryReconciliation:
 
     @pytest.mark.asyncio
     async def test_tracking_disabled_removes_all_trackers(
-        self, hass, entity_registry, mock_coordinator
+        self,
+        hass: HomeAssistant,
+        entity_registry: er.EntityRegistry,
+        mock_coordinator: MagicMock,
     ) -> None:
         """Turning tracking off is a config decision, so it may remove everything."""
         entry = self._entry(hass, mock_coordinator, {})


### PR DESCRIPTION
## Description

Closes #116

### The Problem
In `custom_components/unifi_insights/device_tracker.py`, `async_setup_entry` reconciled the entity registry by deleting every `device_tracker` entry whose `unique_id` was absent from `wanted`. However, `wanted` was built solely from *currently connected* clients in `coordinator.data["clients"]`.

Absence from that snapshot is not evidence that a tracker should be removed:
- A client is missing whenever it is powered off, away, or roaming.
- The entire `clients` key is missing whenever the poll behind `coordinator.data` has failed or has not run yet.

Because this reconciliation runs on every config entry setup (including reboots and option-change reloads), trackers for offline devices were permanently deleted via `registry.async_remove()`. This wiped the entity from Home Assistant, causing:
- Person entities (`Settings -> People`) to lose their assigned device tracker.
- Custom names, custom entity IDs, and area assignments to be permanently lost.
- Trackers to not reappear until the device reconnected, requiring users to manually reconfigure people and dashboard assignments.

Reporting `not_home` for an absent device is the primary purpose of a device tracker; it must survive the device being away or the integration reloading.

### The Fix
Entity removal is now driven by **configuration** rather than by **momentary presence**:

| Situation | Before | After |
|---|:---:|:---:|
| Client tracking disabled entirely | Remove all | Remove all (unchanged) |
| Client connected with a type no longer tracked | Remove | Remove (unchanged) |
| Client absent/offline from snapshot | **Remove (Data Loss)** | **Keep** |

- Replaced `_connected_clients_to_track` with `_partition_connected_clients`, which splits currently connected clients into tracked entries (`wanted: dict[str, str]`) and explicitly untracked entries (`untracked: set[str]`).
- The reconciliation loop only calls `registry.async_remove()` if client tracking is disabled in options or if the entity matches an explicitly connected untracked client type.
- An absent or offline client is never placed into `untracked`, preserving its registry entry and person associations.

### Trade-Off
Disabling one client type (e.g., untracking wired clients) will not immediately delete trackers for clients of that type that happen to be offline at that exact moment. Instead, they are re-examined and removed on the next setup once the client reconnects. A lingering tracker is recoverable; a deleted entity registry entry is not.

---

## Type of Change

- [x] 🐛 **Bug fix** (non-breaking change fixing an issue)
- [ ] ✨ **New feature** (non-breaking change adding functionality)
- [ ] 💥 **Breaking change** (fix or feature causing existing functionality/automations to break)
- [ ] ♻️ **Refactoring** (code organization, no functional change)
- [ ] 📝 **Documentation** (documentation updates only)
- [x] 🧪 **Tests** (adding or improving test coverage)
- [ ] 🔧 **Maintenance / Chore** (dependency updates, tool config, CI)

---

## Architecture & Home Assistant Quality Scale Checklist

- [x] **UniFi Developer Portal**: Checked [developer.ui.com](https://developer.ui.com/) for official specifications.
- [x] **Data Flow**: Entities read solely from `coordinator.data`.
- [x] **API Encapsulation**: Actions and endpoints route through coordinator methods.
- [x] **Base Entities**: Inherits from `UnifiInsightsEntity` with `_attr_has_entity_name = True`.
- [x] **Parallel Updates**: Respects platform update concurrency standards.
- [x] **Error Handling**: Non-destructive error recovery; preserves entities during transient coordinator data gaps.
- [x] **Unique IDs & Device Info**: Unique IDs remain deterministic (`f"{DOMAIN}_{mac}"`).

---

## Validation Checklist

- [x] `script/lint` (Ruff check & format) verified.
- [x] `pytest` passed with ≥ 90% coverage:
  - **1,279 passed** in 18.90s.
  - Overall coverage: **90.51%** (gate: 90%).
  - `custom_components/unifi_insights/device_tracker.py`: **96.59%**.
- [x] Added 6 targeted test cases in `tests/test_device_tracker.py::TestRegistryReconciliation`:
  - **3 regression cases reproducing #116** (assert tracker is kept):
    - `test_absent_client_keeps_its_registry_entry[client_offline]`
    - `test_absent_client_keeps_its_registry_entry[poll_returned_nothing]`
    - `test_absent_client_keeps_its_registry_entry[coordinator_has_no_data]`
    *(Confirmed that reverting `device_tracker.py` to the previous code fails 3/3 on these tests, and passes with this PR).*
  - **3 behaviour-preservation cases** (assert wanted removal still works):
    - `test_connected_client_of_untracked_type_is_removed`
    - `test_connected_tracked_client_is_kept`
    - `test_tracking_disabled_removes_all_trackers`
- [x] Tested live on Home Assistant OS (v2026.9.0) with clean startup across 822 existing `unifi_insights` entities.

---

## Breaking Changes

- [x] No breaking changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Device trackers now remain registered when clients are temporarily absent from connected-client data.
  - Offline or roaming devices continue to report as `not_home`.
  - Trackers are removed when tracking is disabled or when a connected client type is no longer selected for tracking.
  - User customisations are preserved during client data updates.

- **Tests**
  - Added coverage for registry reconciliation across missing data, tracking changes and disabled tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->